### PR TITLE
Add release 13.01 payload transform and NDJSON export

### DIFF
--- a/src/CliReader/ExportOptions.cs
+++ b/src/CliReader/ExportOptions.cs
@@ -1,0 +1,99 @@
+using Replay.Models.Descriptors;
+
+namespace CliReader;
+
+internal sealed record ExportOptions(
+    string ReplayPath,
+    string OutputDirectory,
+    string ProfileName,
+    ParseProfile ParseProfile)
+{
+    public static bool TryParse(string[] args, out ExportOptions? options, out string? error)
+    {
+        options = null;
+        error = null;
+        if (args.Length < 4 || args[0] != "export")
+        {
+            error = Usage;
+            return false;
+        }
+
+        return TryParseArguments(args, out options, out error);
+    }
+
+    public const string Usage =
+        "Usage: CliReader export <replay-path> --output <directory> [--profile viewer]";
+
+    private static bool TryParseArguments(
+        string[] args,
+        out ExportOptions? options,
+        out string? error)
+    {
+        string? outputDirectory = null;
+        var profileName = "default";
+        for (var index = 2; index < args.Length; index += 2)
+        {
+            if (index + 1 >= args.Length)
+            {
+                return Fail($"Missing value for {args[index]}.", out options, out error);
+            }
+
+            if (!TrySetOption(args[index], args[index + 1], ref outputDirectory, ref profileName, out error))
+            {
+                options = null;
+                return false;
+            }
+        }
+
+        if (outputDirectory is null)
+        {
+            return Fail("--output is required.", out options, out error);
+        }
+
+        var profile = profileName == "viewer"
+            ? new ParseProfile
+            {
+                EnabledCategories = ExportCategory.All,
+                CaptureDiagnosticFields = true,
+            }
+            : ParseProfile.Default;
+        options = new ExportOptions(args[1], outputDirectory, profileName, profile);
+        error = null;
+        return true;
+    }
+
+    private static bool TrySetOption(
+        string name,
+        string value,
+        ref string? outputDirectory,
+        ref string profileName,
+        out string? error)
+    {
+        error = null;
+        switch (name)
+        {
+            case "--output" when outputDirectory is null:
+                outputDirectory = value;
+                return true;
+            case "--profile" when profileName == "default" && value == "viewer":
+                profileName = value;
+                return true;
+            case "--profile":
+                error = "Only the 'viewer' export profile is supported.";
+                return false;
+            default:
+                error = $"Unknown or duplicate option '{name}'.";
+                return false;
+        }
+    }
+
+    private static bool Fail(
+        string message,
+        out ExportOptions? options,
+        out string? error)
+    {
+        options = null;
+        error = message;
+        return false;
+    }
+}

--- a/src/CliReader/NdjsonWriter.cs
+++ b/src/CliReader/NdjsonWriter.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+
+namespace CliReader;
+
+internal sealed class NdjsonWriter : IDisposable
+{
+    private readonly Stream _stream;
+
+    public NdjsonWriter(Stream stream)
+    {
+        _stream = stream;
+    }
+
+    public static NdjsonWriter Create(string path)
+    {
+        var stream = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read);
+        return new NdjsonWriter(stream);
+    }
+
+    public void Write(Action<Utf8JsonWriter> writeValue)
+    {
+        using (var writer = new Utf8JsonWriter(_stream))
+        {
+            writeValue(writer);
+            writer.Flush();
+        }
+
+        _stream.WriteByte((byte)'\n');
+    }
+
+    public void Dispose() => _stream.Dispose();
+}

--- a/src/CliReader/Program.cs
+++ b/src/CliReader/Program.cs
@@ -20,6 +20,23 @@ var logger = loggerFactory.CreateLogger("CliReader");
 
 try
 {
+    if (args.Length > 0 && args[0] == "export")
+    {
+        if (!ExportOptions.TryParse(args, out var options, out var error))
+        {
+            logger.LogError("{Error}{NewLine}{Usage}", error, Environment.NewLine, ExportOptions.Usage);
+            return 1;
+        }
+
+        logger.LogInformation(
+            "Exporting replay {ReplayPath} to {OutputDirectory}",
+            options!.ReplayPath,
+            options.OutputDirectory);
+        new ReplayExportRunner(loggerFactory, new ReplayExportManifestWriter()).Run(options);
+        logger.LogInformation("Export complete.");
+        return 0;
+    }
+
     if (args.Length != 1)
     {
         logger.LogError("Usage: CliReader <replay-path>");
@@ -61,6 +78,16 @@ try
 catch (ReplayParseException exception)
 {
     logger.LogError(exception, "Failed to parse replay.");
+    return 1;
+}
+catch (IOException exception)
+{
+    logger.LogError(exception, "Replay input or export output could not be accessed.");
+    return 1;
+}
+catch (UnauthorizedAccessException exception)
+{
+    logger.LogError(exception, "Replay input or export output access was denied.");
     return 1;
 }
 finally

--- a/src/CliReader/Properties/AssemblyInfo.cs
+++ b/src/CliReader/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Replay.Valorant.Tests")]

--- a/src/CliReader/ReplayExportManifestWriter.cs
+++ b/src/CliReader/ReplayExportManifestWriter.cs
@@ -1,0 +1,126 @@
+using System.Reflection;
+using System.Text.Json;
+using Replay.Unreal.Readers;
+using Replay.Valorant;
+
+namespace CliReader;
+
+internal sealed class ReplayExportManifestWriter
+{
+    private const int SchemaVersion = 1;
+
+    public void Write(
+        string outputDirectory,
+        string sourcePath,
+        string sourceSha256,
+        long sourceSize,
+        string profileName,
+        ReplayReaderContext context,
+        ReplayExportSink sink)
+    {
+        var path = Path.Combine(outputDirectory, "manifest.json");
+        var temporaryPath = path + ".tmp";
+        try
+        {
+            using (var stream = new FileStream(
+                       temporaryPath,
+                       FileMode.Create,
+                       FileAccess.Write,
+                       FileShare.None))
+            using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true }))
+            {
+                WriteManifest(
+                    writer,
+                    sourcePath,
+                    sourceSha256,
+                    sourceSize,
+                    profileName,
+                    context,
+                    sink);
+            }
+
+            File.Move(temporaryPath, path, overwrite: true);
+        }
+        catch
+        {
+            File.Delete(temporaryPath);
+            throw;
+        }
+    }
+
+    private static void WriteManifest(
+        Utf8JsonWriter writer,
+        string sourcePath,
+        string sourceSha256,
+        long sourceSize,
+        string profileName,
+        ReplayReaderContext context,
+        ReplayExportSink sink)
+    {
+        var version = context.ReplayVersion;
+        var parserAssembly = typeof(ValorantReplayReader).Assembly;
+
+        writer.WriteStartObject();
+        writer.WriteNumber("schema_version", SchemaVersion);
+        writer.WriteString("source_file", Path.GetFileName(sourcePath));
+        writer.WriteString("source_sha256", sourceSha256);
+        writer.WriteNumber("source_size_bytes", sourceSize);
+        writer.WriteString("replay_build", version.Branch);
+        writer.WriteString("replay_version", $"{version.Major}.{version.Minor}.{version.Patch}");
+        writer.WriteNumber("replay_changelist", version.Changelist);
+        writer.WriteNumber("duration_ms", context.ReplayInfo.LengthInMs);
+        writer.WriteString("parse_profile", profileName);
+        writer.WriteString("parser_assembly", parserAssembly.GetName().Name);
+        writer.WriteString("parser_version", ParserVersion(parserAssembly));
+        WriteStats(writer, context);
+        WriteCounts(writer, sink);
+        WriteLimitations(writer);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteStats(Utf8JsonWriter writer, ReplayReaderContext context)
+    {
+        var stats = context.PacketStats;
+        writer.WriteStartObject("stats");
+        writer.WriteNumber("packet_count", stats.PacketCount);
+        writer.WriteNumber("packets_with_bunches", stats.PacketsWithBunches);
+        writer.WriteNumber("bunch_count", stats.BunchCount);
+        writer.WriteNumber("malformed_packet_count", stats.MalformedPacketCount);
+        writer.WriteNumber("partial_error_count", stats.PartialErrorCount);
+        writer.WriteNumber("total_packet_bytes", stats.TotalPacketBytes);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteCounts(Utf8JsonWriter writer, ReplayExportSink sink)
+    {
+        writer.WriteStartObject("counts");
+        writer.WriteNumber("movement", sink.MovementCount);
+        writer.WriteNumber("events", sink.EventCount);
+        writer.WriteNumber("actor_spawned", sink.ActorSpawnedCount);
+        writer.WriteNumber("actor_closed", sink.ActorClosedCount);
+        writer.WriteNumber("export_group_received", sink.ExportGroupCount);
+        writer.WriteNumber("rpc_received", sink.RpcCount);
+        writer.WriteNumber("filtered_export_groups", sink.FilteredExportGroupCount);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteLimitations(Utf8JsonWriter writer)
+    {
+        writer.WriteStartArray("limitations");
+        writer.WriteStringValue(
+            "Only the latest decoded move in each remote-character update is currently emitted.");
+        writer.WriteStringValue(
+            "Undecoded export groups and decoded export shells without payloads are omitted.");
+        writer.WriteStringValue(
+            "Unknown payload object graphs are bounded to eight levels and 4096 collection items.");
+        writer.WriteEndArray();
+    }
+
+    private static string ParserVersion(Assembly assembly)
+    {
+        return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                   ?.InformationalVersion
+               ?? assembly.GetName().Version?.ToString()
+               ?? "unknown";
+    }
+}

--- a/src/CliReader/ReplayExportManifestWriter.cs
+++ b/src/CliReader/ReplayExportManifestWriter.cs
@@ -7,7 +7,7 @@ namespace CliReader;
 
 internal sealed class ReplayExportManifestWriter
 {
-    private const int SchemaVersion = 1;
+    private const int SchemaVersion = 3;
 
     public void Write(
         string outputDirectory,
@@ -74,6 +74,8 @@ internal sealed class ReplayExportManifestWriter
         writer.WriteString("parser_version", ParserVersion(parserAssembly));
         WriteStats(writer, context);
         WriteCounts(writer, sink);
+        WriteNetFieldExportGroups(writer, context);
+        WriteFilteredExportGroups(writer, sink);
         WriteLimitations(writer);
         writer.WriteEndObject();
     }
@@ -101,7 +103,65 @@ internal sealed class ReplayExportManifestWriter
         writer.WriteNumber("export_group_received", sink.ExportGroupCount);
         writer.WriteNumber("rpc_received", sink.RpcCount);
         writer.WriteNumber("filtered_export_groups", sink.FilteredExportGroupCount);
+        writer.WriteNumber("undecoded_export_groups", sink.UndecodedExportGroupCount);
+        writer.WriteNumber("empty_decoded_export_groups", sink.EmptyDecodedExportGroupCount);
         writer.WriteEndObject();
+    }
+
+    private static void WriteFilteredExportGroups(
+        Utf8JsonWriter writer,
+        ReplayExportSink sink)
+    {
+        writer.WriteStartArray("filtered_export_group_summary");
+        foreach (var summary in sink.FilteredExportGroups
+                     .OrderByDescending(item => item.Count)
+                     .ThenBy(item => item.Path, StringComparer.Ordinal))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("path", summary.Path);
+            writer.WriteString("kind", ReplayJsonNormalizer.ToSnakeCase(summary.Kind.ToString()));
+            writer.WriteBoolean("was_decoded", summary.WasDecoded);
+            writer.WriteNumber("count", summary.Count);
+            writer.WriteNumber("payload_bits", summary.PayloadBits);
+            writer.WriteNumber("sample_actor_net_guid", summary.ActorNetGuid);
+            writer.WriteNumber("sample_object_net_guid", summary.ObjectNetGuid);
+            writer.WriteNumber("sample_class_net_guid", summary.ClassNetGuid);
+            writer.WriteNumber("sample_outer_net_guid", summary.OuterNetGuid);
+            writer.WriteString("sample_object_path", summary.ObjectPath);
+            writer.WriteString("sample_class_path", summary.ClassPath);
+            writer.WriteString("sample_outer_path", summary.OuterPath);
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+    }
+
+    private static void WriteNetFieldExportGroups(
+        Utf8JsonWriter writer,
+        ReplayReaderContext context)
+    {
+        writer.WriteStartArray("net_field_export_groups");
+        foreach (var group in context.NetGuidCache.ExportGroupsByPath.Values
+                     .OrderBy(item => item.PathName, StringComparer.Ordinal))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("path", group.PathName);
+            writer.WriteNumber("path_name_index", group.PathNameIndex);
+            writer.WriteStartArray("fields");
+            foreach (var field in group.NetFieldExports.Where(item => item is not null))
+            {
+                writer.WriteStartObject();
+                writer.WriteNumber("handle", field!.Handle);
+                writer.WriteString("name", field.Name);
+                writer.WriteNumber("compatible_checksum", field.CompatibleChecksum);
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
     }
 
     private static void WriteLimitations(Utf8JsonWriter writer)

--- a/src/CliReader/ReplayExportRunner.cs
+++ b/src/CliReader/ReplayExportRunner.cs
@@ -1,0 +1,57 @@
+using System.Security.Cryptography;
+using Microsoft.Extensions.Logging;
+using Replay.Encoding.Archives;
+using Replay.Unreal.Readers;
+using Replay.Valorant;
+
+namespace CliReader;
+
+internal sealed class ReplayExportRunner
+{
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ReplayExportManifestWriter _manifestWriter;
+
+    public ReplayExportRunner(
+        ILoggerFactory loggerFactory,
+        ReplayExportManifestWriter manifestWriter)
+    {
+        _loggerFactory = loggerFactory;
+        _manifestWriter = manifestWriter;
+    }
+
+    public void Run(ExportOptions options)
+    {
+        var outputDirectory = Path.GetFullPath(options.OutputDirectory);
+        Directory.CreateDirectory(outputDirectory);
+        File.Delete(Path.Combine(outputDirectory, "manifest.json"));
+
+        using var file = File.OpenRead(options.ReplayPath);
+        var sourceSize = file.Length;
+        var sourceSha256 = Convert.ToHexString(SHA256.HashData(file)).ToLowerInvariant();
+        file.Position = 0;
+
+        var sink = ReplayExportSink.Create(outputDirectory);
+        ReplayReaderContext context;
+        try
+        {
+            using var archive = new FBinaryArchive(file);
+            context = ValorantReplayReader.CreateDefault(
+                _loggerFactory,
+                sink,
+                options.ParseProfile).Read(archive);
+        }
+        finally
+        {
+            sink.Dispose();
+        }
+
+        _manifestWriter.Write(
+            outputDirectory,
+            options.ReplayPath,
+            sourceSha256,
+            sourceSize,
+            options.ProfileName,
+            context,
+            sink);
+    }
+}

--- a/src/CliReader/ReplayExportSink.cs
+++ b/src/CliReader/ReplayExportSink.cs
@@ -14,6 +14,8 @@ internal sealed class ReplayExportSink :
     private readonly NdjsonWriter _events;
     private readonly NdjsonWriter _movement;
     private readonly ReplayJsonNormalizer _normalizer;
+    private readonly Dictionary<(string Path, ExportGroupKind Kind, bool WasDecoded), FilteredExportGroupSummary>
+        _filteredExportGroups = [];
 
     internal ReplayExportSink(
         NdjsonWriter events,
@@ -29,9 +31,13 @@ internal sealed class ReplayExportSink :
     public int ActorClosedCount { get; private set; }
     public int ExportGroupCount { get; private set; }
     public int FilteredExportGroupCount { get; private set; }
+    public int UndecodedExportGroupCount { get; private set; }
+    public int EmptyDecodedExportGroupCount { get; private set; }
     public int RpcCount { get; private set; }
     public int MovementCount { get; private set; }
     public int EventCount => ActorSpawnedCount + ActorClosedCount + ExportGroupCount + RpcCount;
+    public IReadOnlyCollection<FilteredExportGroupSummary> FilteredExportGroups =>
+        _filteredExportGroups.Values;
 
     public static ReplayExportSink Create(string outputDirectory)
     {
@@ -158,6 +164,7 @@ internal sealed class ReplayExportSink :
     {
         if (!exportGroup.WasDecoded || exportGroup.Payload is null)
         {
+            RecordFilteredExportGroup(exportGroup);
             FilteredExportGroupCount++;
             return;
         }
@@ -183,6 +190,27 @@ internal sealed class ReplayExportSink :
             writer.WriteEndObject();
         });
         ExportGroupCount++;
+    }
+
+    private void RecordFilteredExportGroup(ExportGroupReceived exportGroup)
+    {
+        var path = exportGroup.ExportGroupPath ?? exportGroup.ClassPath ?? "<unresolved>";
+        var key = (path, exportGroup.Kind, exportGroup.WasDecoded);
+        if (!_filteredExportGroups.TryGetValue(key, out var summary))
+        {
+            summary = new FilteredExportGroupSummary(path, exportGroup.Kind, exportGroup.WasDecoded);
+            _filteredExportGroups.Add(key, summary);
+        }
+
+        summary.Add(exportGroup);
+        if (exportGroup.WasDecoded)
+        {
+            EmptyDecodedExportGroupCount++;
+        }
+        else
+        {
+            UndecodedExportGroupCount++;
+        }
     }
 
     private void WriteRpc(RpcReceived rpc)
@@ -373,5 +401,42 @@ internal sealed class ReplayExportSink :
     {
         if (value is null) writer.WriteNull(name);
         else writer.WriteBoolean(name, value.Value);
+    }
+}
+
+internal sealed class FilteredExportGroupSummary(
+    string path,
+    ExportGroupKind kind,
+    bool wasDecoded)
+{
+    public string Path { get; } = path;
+    public ExportGroupKind Kind { get; } = kind;
+    public bool WasDecoded { get; } = wasDecoded;
+    public int Count { get; private set; }
+    public long PayloadBits { get; private set; }
+    public uint ActorNetGuid { get; private set; }
+    public uint ObjectNetGuid { get; private set; }
+    public uint ClassNetGuid { get; private set; }
+    public uint OuterNetGuid { get; private set; }
+    public string? ObjectPath { get; private set; }
+    public string? ClassPath { get; private set; }
+    public string? OuterPath { get; private set; }
+
+    public void Add(ExportGroupReceived exportGroup)
+    {
+        Count++;
+        PayloadBits += exportGroup.PayloadBits;
+        if (Count != 1)
+        {
+            return;
+        }
+
+        ActorNetGuid = exportGroup.ActorNetGuid;
+        ObjectNetGuid = exportGroup.ObjectNetGuid;
+        ClassNetGuid = exportGroup.ClassNetGuid;
+        OuterNetGuid = exportGroup.OuterNetGuid;
+        ObjectPath = exportGroup.ObjectPath;
+        ClassPath = exportGroup.ClassPath;
+        OuterPath = exportGroup.OuterPath;
     }
 }

--- a/src/CliReader/ReplayExportSink.cs
+++ b/src/CliReader/ReplayExportSink.cs
@@ -1,0 +1,377 @@
+using System.Text.Json;
+using Replay.Models.Descriptors;
+using Replay.Models.Events;
+using Replay.Models.Unreal;
+using Replay.Valorant.Movement;
+
+namespace CliReader;
+
+internal sealed class ReplayExportSink :
+    IReplayEventSink,
+    IRemoteCharacterMovementSink,
+    IDisposable
+{
+    private readonly NdjsonWriter _events;
+    private readonly NdjsonWriter _movement;
+    private readonly ReplayJsonNormalizer _normalizer;
+
+    internal ReplayExportSink(
+        NdjsonWriter events,
+        NdjsonWriter movement,
+        ReplayJsonNormalizer normalizer)
+    {
+        _events = events;
+        _movement = movement;
+        _normalizer = normalizer;
+    }
+
+    public int ActorSpawnedCount { get; private set; }
+    public int ActorClosedCount { get; private set; }
+    public int ExportGroupCount { get; private set; }
+    public int FilteredExportGroupCount { get; private set; }
+    public int RpcCount { get; private set; }
+    public int MovementCount { get; private set; }
+    public int EventCount => ActorSpawnedCount + ActorClosedCount + ExportGroupCount + RpcCount;
+
+    public static ReplayExportSink Create(string outputDirectory)
+    {
+        Directory.CreateDirectory(outputDirectory);
+        var events = NdjsonWriter.Create(Path.Combine(outputDirectory, "events.ndjson"));
+        try
+        {
+            var movement = NdjsonWriter.Create(Path.Combine(outputDirectory, "movement.ndjson"));
+            return new ReplayExportSink(events, movement, new ReplayJsonNormalizer());
+        }
+        catch
+        {
+            events.Dispose();
+            throw;
+        }
+    }
+
+    public void Emit(ReplayEvent replayEvent)
+    {
+        switch (replayEvent)
+        {
+            case ActorSpawned spawned:
+                WriteActorSpawned(spawned);
+                break;
+            case ActorClosed closed:
+                WriteActorClosed(closed);
+                break;
+            case ExportGroupReceived exportGroup:
+                WriteExportGroup(exportGroup);
+                break;
+            case RpcReceived rpc:
+                WriteRpc(rpc);
+                break;
+            case RemoteCharacterMovementReceived movement:
+                var move = movement.Move;
+                EmitRemoteCharacterMovement(
+                    movement.TimeSeconds,
+                    movement.PacketId,
+                    movement.ActorNetGuid,
+                    movement.ObjectNetGuid,
+                    movement.ChannelIndex,
+                    movement.UpdateIndex,
+                    movement.ShooterCharacterNetGuidValue,
+                    movement.MoveIndex,
+                    in move);
+                break;
+        }
+    }
+
+    public void EmitRemoteCharacterMovement(
+        float timeSeconds,
+        int packetId,
+        uint actorNetGuid,
+        uint objectNetGuid,
+        uint channelIndex,
+        int updateIndex,
+        uint shooterCharacterNetGuidValue,
+        int moveIndex,
+        in MovementMove move)
+    {
+        var value = move;
+        _movement.Write(writer => WriteMovement(
+            writer,
+            timeSeconds,
+            packetId,
+            actorNetGuid,
+            objectNetGuid,
+            channelIndex,
+            updateIndex,
+            shooterCharacterNetGuidValue,
+            moveIndex,
+            value));
+        MovementCount++;
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            _events.Dispose();
+        }
+        finally
+        {
+            _movement.Dispose();
+        }
+    }
+
+    private void WriteActorSpawned(ActorSpawned spawned)
+    {
+        _events.Write(writer =>
+        {
+            WriteEventStart(writer, "actor_spawned", spawned);
+            writer.WriteNumber("actor_net_guid", spawned.ActorNetGuid);
+            writer.WriteNumber("channel", spawned.ChannelIndex);
+            writer.WriteBoolean("is_dynamic", spawned.IsDynamic);
+            WriteNullableString(writer, "actor_path", spawned.ActorPath);
+            writer.WriteNumber("archetype_net_guid", spawned.ArchetypeNetGuid);
+            WriteNullableString(writer, "archetype_path", spawned.ArchetypePath);
+            WriteNullableString(writer, "replication_class_path", spawned.ReplicationClassPath);
+            writer.WriteNumber("level_net_guid", spawned.LevelNetGuid);
+            WriteNullableValue(writer, "location", spawned.Location);
+            WriteNullableValue(writer, "rotation", spawned.Rotation);
+            WriteNullableValue(writer, "scale", spawned.Scale);
+            WriteNullableValue(writer, "velocity", spawned.Velocity);
+            writer.WriteEndObject();
+        });
+        ActorSpawnedCount++;
+    }
+
+    private void WriteActorClosed(ActorClosed closed)
+    {
+        _events.Write(writer =>
+        {
+            WriteEventStart(writer, "actor_closed", closed);
+            writer.WriteNumber("actor_net_guid", closed.ActorNetGuid);
+            writer.WriteNumber("channel", closed.ChannelIndex);
+            writer.WriteString("reason", ReplayJsonNormalizer.ToSnakeCase(closed.Reason.ToString()));
+            writer.WriteEndObject();
+        });
+        ActorClosedCount++;
+    }
+
+    private void WriteExportGroup(ExportGroupReceived exportGroup)
+    {
+        if (!exportGroup.WasDecoded || exportGroup.Payload is null)
+        {
+            FilteredExportGroupCount++;
+            return;
+        }
+
+        _events.Write(writer =>
+        {
+            WriteEventStart(writer, "export_group_received", exportGroup);
+            WriteObjectIdentity(writer, exportGroup.ActorNetGuid, exportGroup.ObjectNetGuid, exportGroup.ChannelIndex);
+            writer.WriteBoolean("is_actor", exportGroup.IsActor);
+            writer.WriteBoolean("is_deleted", exportGroup.IsDeleted);
+            writer.WriteNumber("delete_flags", exportGroup.DeleteFlags);
+            WriteNullableString(writer, "export_group_path", exportGroup.ExportGroupPath);
+            writer.WriteString("kind", ReplayJsonNormalizer.ToSnakeCase(exportGroup.Kind.ToString()));
+            WriteCategories(writer, exportGroup.Categories);
+            writer.WriteNumber("class_net_guid", exportGroup.ClassNetGuid);
+            writer.WriteNumber("outer_net_guid", exportGroup.OuterNetGuid);
+            WriteNullableString(writer, "object_path", exportGroup.ObjectPath);
+            WriteNullableString(writer, "class_path", exportGroup.ClassPath);
+            WriteNullableString(writer, "outer_path", exportGroup.OuterPath);
+            WriteDecodeMetadata(writer, exportGroup.PayloadBits, exportGroup.ParsedBits, true, exportGroup.DecodedFieldCount);
+            WritePayload(writer, exportGroup.Payload);
+            WriteDiagnosticFields(writer, exportGroup.DiagnosticFields);
+            writer.WriteEndObject();
+        });
+        ExportGroupCount++;
+    }
+
+    private void WriteRpc(RpcReceived rpc)
+    {
+        _events.Write(writer =>
+        {
+            WriteEventStart(writer, "rpc_received", rpc);
+            WriteObjectIdentity(writer, rpc.ActorNetGuid, rpc.ObjectNetGuid, rpc.ChannelIndex);
+            writer.WriteString("class_path", rpc.ClassPath);
+            writer.WriteString("function_name", rpc.FunctionName);
+            writer.WriteString("function_export_path", rpc.FunctionExportPath);
+            writer.WriteNumber("function_handle", rpc.FunctionHandle);
+            WriteCategories(writer, rpc.Categories);
+            WriteDecodeMetadata(writer, rpc.PayloadBits, rpc.ParsedBits, rpc.WasDecoded, rpc.DecodedFieldCount);
+            WritePayload(writer, rpc.Payload);
+            WriteDiagnosticFields(writer, rpc.DiagnosticFields);
+            writer.WriteEndObject();
+        });
+        RpcCount++;
+    }
+
+    private void WriteMovement(
+        Utf8JsonWriter writer,
+        float timeSeconds,
+        int packetId,
+        uint actorNetGuid,
+        uint objectNetGuid,
+        uint channelIndex,
+        int updateIndex,
+        uint shooterCharacterNetGuid,
+        int moveIndex,
+        MovementMove move)
+    {
+        writer.WriteStartObject();
+        WriteEventDiscriminator(writer, "remote_character_movement", timeSeconds, packetId);
+        WriteObjectIdentity(writer, actorNetGuid, objectNetGuid, channelIndex);
+        writer.WriteNumber("shooter_character_net_guid", shooterCharacterNetGuid);
+        writer.WriteNumber("update_index", updateIndex);
+        writer.WriteNumber("move_index", moveIndex);
+        writer.WritePropertyName("position");
+        ReplayJsonNormalizer.WriteVector(writer, move.Position);
+        writer.WriteNumber("yaw", move.Yaw);
+        writer.WriteNumber("pitch", move.Pitch);
+        WriteNullableValue(writer, "velocity", move.Velocity);
+        writer.WriteNumber("timestamp", move.Timestamp);
+        writer.WriteNumber("movement_state", move.MovementState);
+        writer.WriteNumber("mode_flags", move.ModeFlags);
+        writer.WriteNumber("marker", move.Marker);
+        writer.WriteNumber("move_type", move.MoveType);
+        writer.WritePropertyName("rotation_input");
+        ReplayJsonNormalizer.WriteVector(writer, move.RotationInput);
+        WriteNullableValue(writer, "variant1_vector", move.Variant1Vector);
+        writer.WriteNumber("rotation_yaw_multiplier", move.RotationYawMultiplier);
+        writer.WriteBoolean("has_optional_movement_value", move.HasOptionalMovementValue);
+        WriteNullableNumber(writer, "optional_movement_raw_byte", move.OptionalMovementRawByte);
+        WriteNullableNumber(writer, "optional_movement_value", move.OptionalMovementValue);
+        writer.WriteBoolean("flag48", move.Flag48);
+        writer.WriteNumber("packed_angles", move.PackedAngles);
+        writer.WriteNumber("raw_yaw", move.RawYaw);
+        writer.WriteNumber("raw_pitch", move.RawPitch);
+        WriteNullableBoolean(writer, "variant0_has_external_character_ref", move.Variant0HasExternalCharacterRef);
+        WriteNullableNumber(writer, "variant0_packed_angles", move.Variant0PackedAngles);
+        WriteNullableBoolean(writer, "variant1_flag", move.Variant1Flag);
+        writer.WriteBoolean("error_sentinel", move.ErrorSentinel);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteEventStart(Utf8JsonWriter writer, string type, ReplayEvent replayEvent)
+    {
+        writer.WriteStartObject();
+        WriteEventDiscriminator(writer, type, replayEvent.TimeSeconds, replayEvent.PacketId);
+    }
+
+    private static void WriteEventDiscriminator(
+        Utf8JsonWriter writer,
+        string type,
+        float timeSeconds,
+        int packetId)
+    {
+        writer.WriteString("type", type);
+        writer.WriteNumber("time_ms", ToMilliseconds(timeSeconds));
+        writer.WriteNumber("packet_id", packetId);
+    }
+
+    private static long ToMilliseconds(float seconds) =>
+        float.IsFinite(seconds)
+            ? (long)Math.Round(seconds * 1000d, MidpointRounding.AwayFromZero)
+            : 0;
+
+    private static void WriteObjectIdentity(
+        Utf8JsonWriter writer,
+        uint actorNetGuid,
+        uint objectNetGuid,
+        uint channelIndex)
+    {
+        writer.WriteNumber("actor_net_guid", actorNetGuid);
+        writer.WriteNumber("object_net_guid", objectNetGuid);
+        writer.WriteNumber("channel", channelIndex);
+    }
+
+    private static void WriteDecodeMetadata(
+        Utf8JsonWriter writer,
+        int payloadBits,
+        int parsedBits,
+        bool wasDecoded,
+        int decodedFieldCount)
+    {
+        writer.WriteNumber("payload_bits", payloadBits);
+        writer.WriteNumber("parsed_bits", parsedBits);
+        writer.WriteBoolean("was_decoded", wasDecoded);
+        writer.WriteNumber("decoded_field_count", decodedFieldCount);
+    }
+
+    private void WritePayload(Utf8JsonWriter writer, object? payload)
+    {
+        writer.WritePropertyName("payload");
+        _normalizer.WriteValue(writer, payload);
+    }
+
+    private void WriteDiagnosticFields(
+        Utf8JsonWriter writer,
+        IReadOnlyList<DecodedReplayField> fields)
+    {
+        writer.WriteStartArray("diagnostic_fields");
+        foreach (var field in fields)
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber("handle", field.Handle);
+            WriteNullableString(writer, "name", field.Name);
+            WriteNullableString(writer, "export_name", field.ExportName);
+            WriteCategories(writer, field.Categories);
+            writer.WritePropertyName("value");
+            _normalizer.WriteValue(writer, field.Value);
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+    }
+
+    private static void WriteCategories(Utf8JsonWriter writer, ExportCategory categories)
+    {
+        writer.WriteStartArray("categories");
+        foreach (var category in Enum.GetValues<ExportCategory>())
+        {
+            if (category is ExportCategory.None or ExportCategory.All ||
+                !categories.HasFlag(category))
+            {
+                continue;
+            }
+
+            writer.WriteStringValue(ReplayJsonNormalizer.ToSnakeCase(category.ToString()));
+        }
+
+        writer.WriteEndArray();
+    }
+
+    private void WriteNullableValue(Utf8JsonWriter writer, string name, object? value)
+    {
+        writer.WritePropertyName(name);
+        _normalizer.WriteValue(writer, value);
+    }
+
+    private static void WriteNullableString(Utf8JsonWriter writer, string name, string? value)
+    {
+        if (value is null) writer.WriteNull(name);
+        else writer.WriteString(name, value);
+    }
+
+    private static void WriteNullableNumber(Utf8JsonWriter writer, string name, uint? value)
+    {
+        if (value is null) writer.WriteNull(name);
+        else writer.WriteNumber(name, value.Value);
+    }
+
+    private static void WriteNullableNumber(Utf8JsonWriter writer, string name, byte? value)
+    {
+        if (value is null) writer.WriteNull(name);
+        else writer.WriteNumber(name, value.Value);
+    }
+
+    private static void WriteNullableNumber(Utf8JsonWriter writer, string name, double? value)
+    {
+        if (value is null || !double.IsFinite(value.Value)) writer.WriteNull(name);
+        else writer.WriteNumber(name, value.Value);
+    }
+
+    private static void WriteNullableBoolean(Utf8JsonWriter writer, string name, bool? value)
+    {
+        if (value is null) writer.WriteNull(name);
+        else writer.WriteBoolean(name, value.Value);
+    }
+}

--- a/src/CliReader/ReplayJsonNormalizer.cs
+++ b/src/CliReader/ReplayJsonNormalizer.cs
@@ -1,0 +1,346 @@
+using System.Collections;
+using System.Reflection;
+using System.Text.Json;
+using Replay.Models.Descriptors;
+using Replay.Models.Unreal;
+
+namespace CliReader;
+
+internal sealed class ReplayJsonNormalizer
+{
+    private const int MaxDepth = 8;
+    private const int MaxCollectionItems = 4096;
+
+    public void WriteValue(Utf8JsonWriter writer, object? value)
+    {
+        WriteValue(writer, value, 0, new HashSet<object>(ReferenceEqualityComparer.Instance));
+    }
+
+    private void WriteValue(
+        Utf8JsonWriter writer,
+        object? value,
+        int depth,
+        HashSet<object> ancestors)
+    {
+        if (value is null || depth > MaxDepth)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        if (TryWriteScalar(writer, value) || TryWriteUnrealValue(writer, value, depth, ancestors))
+        {
+            return;
+        }
+
+        if (!value.GetType().IsValueType && !ancestors.Add(value))
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        try
+        {
+            WriteComplexValue(writer, value, depth, ancestors);
+        }
+        finally
+        {
+            if (!value.GetType().IsValueType)
+            {
+                ancestors.Remove(value);
+            }
+        }
+    }
+
+    private static bool TryWriteScalar(Utf8JsonWriter writer, object value)
+    {
+        switch (value)
+        {
+            case string text:
+                writer.WriteStringValue(text);
+                return true;
+            case bool boolean:
+                writer.WriteBooleanValue(boolean);
+                return true;
+            case byte number:
+                writer.WriteNumberValue(number);
+                return true;
+            case sbyte number:
+                writer.WriteNumberValue(number);
+                return true;
+            case short number:
+                writer.WriteNumberValue(number);
+                return true;
+            case ushort number:
+                writer.WriteNumberValue(number);
+                return true;
+            case int number:
+                writer.WriteNumberValue(number);
+                return true;
+            case uint number:
+                writer.WriteNumberValue(number);
+                return true;
+            case long number:
+                writer.WriteNumberValue(number);
+                return true;
+            case ulong number:
+                writer.WriteNumberValue(number);
+                return true;
+            case float number:
+                WriteFiniteNumber(writer, number);
+                return true;
+            case double number:
+                WriteFiniteNumber(writer, number);
+                return true;
+            case decimal number:
+                writer.WriteNumberValue(number);
+                return true;
+            case char character:
+                writer.WriteStringValue(character.ToString());
+                return true;
+            case Enum enumValue:
+                writer.WriteStringValue(ToSnakeCase(enumValue.ToString()));
+                return true;
+            case Guid guid:
+                writer.WriteStringValue(guid);
+                return true;
+            case DateTime dateTime:
+                writer.WriteStringValue(dateTime);
+                return true;
+            case DateTimeOffset dateTimeOffset:
+                writer.WriteStringValue(dateTimeOffset);
+                return true;
+            case byte[] bytes:
+                writer.WriteBase64StringValue(bytes);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private bool TryWriteUnrealValue(
+        Utf8JsonWriter writer,
+        object value,
+        int depth,
+        HashSet<object> ancestors)
+    {
+        switch (value)
+        {
+            case FVector vector:
+                WriteVector(writer, vector);
+                return true;
+            case FRotator rotator:
+                WriteRotator(writer, rotator);
+                return true;
+            case FRepMovement movement:
+                WriteRepMovement(writer, movement, depth, ancestors);
+                return true;
+            case DecodedFieldValue fieldValue:
+                WriteDecodedFieldValue(writer, fieldValue, depth, ancestors);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void WriteComplexValue(
+        Utf8JsonWriter writer,
+        object value,
+        int depth,
+        HashSet<object> ancestors)
+    {
+        switch (value)
+        {
+            case IDictionary dictionary:
+                WriteDictionary(writer, dictionary, depth, ancestors);
+                break;
+            case IEnumerable enumerable:
+                WriteEnumerable(writer, enumerable, depth, ancestors);
+                break;
+            case IDecodedPayload payload:
+                WriteObject(writer, value, PayloadProperties(value, payload), depth, ancestors);
+                break;
+            default:
+                WriteObject(writer, value, PublicProperties(value), depth, ancestors);
+                break;
+        }
+    }
+
+    private void WriteDictionary(
+        Utf8JsonWriter writer,
+        IDictionary dictionary,
+        int depth,
+        HashSet<object> ancestors)
+    {
+        var entries = dictionary.Keys.Cast<object?>()
+            .Select(key => (Name: key?.ToString() ?? "null", Value: key is null ? null : dictionary[key]))
+            .OrderBy(entry => entry.Name, StringComparer.Ordinal)
+            .Take(MaxCollectionItems);
+        writer.WriteStartObject();
+        foreach (var entry in entries)
+        {
+            writer.WritePropertyName(entry.Name);
+            WriteValue(writer, entry.Value, depth + 1, ancestors);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private void WriteEnumerable(
+        Utf8JsonWriter writer,
+        IEnumerable enumerable,
+        int depth,
+        HashSet<object> ancestors)
+    {
+        writer.WriteStartArray();
+        foreach (var item in enumerable.Cast<object?>().Take(MaxCollectionItems))
+        {
+            WriteValue(writer, item, depth + 1, ancestors);
+        }
+
+        writer.WriteEndArray();
+    }
+
+    private void WriteObject(
+        Utf8JsonWriter writer,
+        object value,
+        IEnumerable<PropertyInfo> properties,
+        int depth,
+        HashSet<object> ancestors)
+    {
+        writer.WriteStartObject();
+        foreach (var property in properties)
+        {
+            writer.WritePropertyName(property.Name);
+            WriteValue(writer, ReadProperty(property, value), depth + 1, ancestors);
+        }
+
+        writer.WriteEndObject();
+    }
+
+    private static IEnumerable<PropertyInfo> PayloadProperties(object value, IDecodedPayload payload)
+    {
+        var type = value.GetType();
+        return payload.DecodedProperties
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .Select(name => type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public))
+            .Where(property => property is not null && property.GetIndexParameters().Length == 0)!;
+    }
+
+    private static IEnumerable<PropertyInfo> PublicProperties(object value) =>
+        value.GetType()
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(property => property.CanRead && property.GetIndexParameters().Length == 0)
+            .OrderBy(property => property.Name, StringComparer.Ordinal)
+            .Take(MaxCollectionItems);
+
+    private static object? ReadProperty(PropertyInfo property, object value)
+    {
+        try
+        {
+            return property.GetValue(value);
+        }
+        catch (TargetInvocationException)
+        {
+            return null;
+        }
+    }
+
+    private void WriteRepMovement(
+        Utf8JsonWriter writer,
+        FRepMovement movement,
+        int depth,
+        HashSet<object> ancestors)
+    {
+        writer.WriteStartObject();
+        WriteProperty(writer, "linear_velocity", movement.LinearVelocity, depth, ancestors);
+        WriteProperty(writer, "angular_velocity", movement.AngularVelocity, depth, ancestors);
+        WriteProperty(writer, "location", movement.Location, depth, ancestors);
+        WriteProperty(writer, "rotation", movement.Rotation, depth, ancestors);
+        writer.WriteBoolean("simulated_physics_sleep", movement.bSimulatedPhysicsSleep);
+        writer.WriteBoolean("rep_physics", movement.bRepPhysics);
+        writer.WriteNumber("server_frame", movement.ServerFrame);
+        writer.WriteNumber("server_physics_handle", movement.ServerPhysicsHandle);
+        writer.WriteEndObject();
+    }
+
+    private void WriteDecodedFieldValue(
+        Utf8JsonWriter writer,
+        DecodedFieldValue value,
+        int depth,
+        HashSet<object> ancestors)
+    {
+        object? normalized = value.Kind switch
+        {
+            DecodedFieldValueKind.Bool => value.BoolValue,
+            DecodedFieldValueKind.Byte => value.ByteValue,
+            DecodedFieldValueKind.Int32 => value.Int32Value,
+            DecodedFieldValueKind.UInt32 => value.UInt32Value,
+            DecodedFieldValueKind.Float => value.FloatValue,
+            DecodedFieldValueKind.Double => value.DoubleValue,
+            DecodedFieldValueKind.String => value.StringValue,
+            DecodedFieldValueKind.NetGuid => value.NetGuidValue,
+            DecodedFieldValueKind.Vector => value.VectorValue,
+            DecodedFieldValueKind.Rotator => value.RotatorValue,
+            DecodedFieldValueKind.RepMovement => value.RepMovementValue,
+            DecodedFieldValueKind.Object => value.ObjectValue,
+            _ => null,
+        };
+        WriteValue(writer, normalized, depth + 1, ancestors);
+    }
+
+    private void WriteProperty(
+        Utf8JsonWriter writer,
+        string name,
+        object? value,
+        int depth,
+        HashSet<object> ancestors)
+    {
+        writer.WritePropertyName(name);
+        WriteValue(writer, value, depth + 1, ancestors);
+    }
+
+    internal static void WriteVector(Utf8JsonWriter writer, FVector vector)
+    {
+        writer.WriteStartObject();
+        WriteFiniteNumber(writer, "x", vector.X);
+        WriteFiniteNumber(writer, "y", vector.Y);
+        WriteFiniteNumber(writer, "z", vector.Z);
+        writer.WriteEndObject();
+    }
+
+    internal static void WriteRotator(Utf8JsonWriter writer, FRotator rotator)
+    {
+        writer.WriteStartObject();
+        WriteFiniteNumber(writer, "pitch", rotator.Pitch);
+        WriteFiniteNumber(writer, "yaw", rotator.Yaw);
+        WriteFiniteNumber(writer, "roll", rotator.Roll);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteFiniteNumber(Utf8JsonWriter writer, float value)
+    {
+        if (float.IsFinite(value)) writer.WriteNumberValue(value);
+        else writer.WriteNullValue();
+    }
+
+    private static void WriteFiniteNumber(Utf8JsonWriter writer, double value)
+    {
+        if (double.IsFinite(value)) writer.WriteNumberValue(value);
+        else writer.WriteNullValue();
+    }
+
+    private static void WriteFiniteNumber(Utf8JsonWriter writer, string name, double value)
+    {
+        writer.WritePropertyName(name);
+        WriteFiniteNumber(writer, value);
+    }
+
+    internal static string ToSnakeCase(string value)
+    {
+        return string.Concat(value.SelectMany((character, index) =>
+            index > 0 && char.IsUpper(character)
+                ? new[] { '_', char.ToLowerInvariant(character) }
+                : new[] { char.ToLowerInvariant(character) }));
+    }
+}

--- a/src/CliReader/ReplayJsonNormalizer.cs
+++ b/src/CliReader/ReplayJsonNormalizer.cs
@@ -8,7 +8,7 @@ namespace CliReader;
 
 internal sealed class ReplayJsonNormalizer
 {
-    private const int MaxDepth = 8;
+    private const int MaxDepth = 12;
     private const int MaxCollectionItems = 4096;
 
     public void WriteValue(Utf8JsonWriter writer, object? value)

--- a/src/Replay.Encoding/PayloadEncryption/PayloadTransformRegistry.cs
+++ b/src/Replay.Encoding/PayloadEncryption/PayloadTransformRegistry.cs
@@ -26,6 +26,7 @@ public sealed class PayloadTransformRegistry
         new ValorantSeededTransform12_10(),
         new ValorantSeededTransform12_11(),
         new ValorantSeededTransform13_00(),
+        new ValorantSeededTransform13_01(),
     ]);
 
     public IPayloadTransform GetRequired(string replayVersion)

--- a/src/Replay.Encoding/PayloadEncryption/VersionedTransforms/ValorantSeededTransform13_01.cs
+++ b/src/Replay.Encoding/PayloadEncryption/VersionedTransforms/ValorantSeededTransform13_01.cs
@@ -1,0 +1,122 @@
+using Replay.Encoding.Archives;
+using static Replay.Encoding.PayloadEncryption.ValorantSeededTransformHelpers;
+
+namespace Replay.Encoding.PayloadEncryption.VersionedTransforms;
+
+public sealed class ValorantSeededTransform13_01 : IPayloadTransform
+{
+    private const uint SeedAddend = 0xe62fcd5cu;
+    private const uint InitAOffset = 0x24u;
+    private const byte TailXor = 0x5c;
+
+    public IReadOnlyCollection<string> SupportedReplayVersions { get; } = ["++Ares-Core+release-13.01"];
+
+    public int GetOutputByteCount(int bitCount) => ValorantSeededTransformHelpers.GetOutputByteCount(bitCount);
+
+    public void Apply(FBitArchive input, uint seed, Span<byte> output)
+    {
+        var bitCount = CopyInputToOutput(input, output);
+        Transform(output[..GetOutputByteCount(bitCount)], bitCount, seed);
+    }
+
+    public void Apply(FBitArchive input, int bitCount, uint seed, Span<byte> output)
+    {
+        CopyInputToOutput(input, bitCount, output);
+        Transform(output[..GetOutputByteCount(bitCount)], bitCount, seed);
+    }
+
+    private static void Transform(Span<byte> output, int bitCount, uint seed)
+    {
+        if (bitCount == 0)
+        {
+            return;
+        }
+
+        var state = seed;
+        var streamByte = (byte)seed;
+        var prngA = InitialPrngA(seed);
+        var prngB = InitialPrngB(seed);
+        var byteOffset = 0;
+        var bitsRemaining = bitCount;
+
+        unchecked
+        {
+            while (bitsRemaining > 63)
+            {
+                var value = TransformUInt64(ReadUInt64(output, byteOffset), state);
+                WriteUInt64(output, byteOffset, value);
+                AdvanceTransformState(ref state, ref prngA, ref prngB, out streamByte);
+                byteOffset += 8;
+                bitsRemaining -= 64;
+            }
+
+            while (bitsRemaining > 31)
+            {
+                var value = TransformUInt32(ReadUInt32(output, byteOffset), state);
+                WriteUInt32(output, byteOffset, value);
+                AdvanceTransformState(ref state, ref prngA, ref prngB, out streamByte);
+                byteOffset += 4;
+                bitsRemaining -= 32;
+            }
+
+            while (bitsRemaining > 7)
+            {
+                output[byteOffset] = TransformByte(output[byteOffset], state);
+                AdvanceTransformState(ref state, ref prngA, ref prngB, out streamByte);
+                byteOffset++;
+                bitsRemaining -= 8;
+            }
+
+            if (bitsRemaining != 0)
+            {
+                var mask = (byte)(0xff >> (7 - ((bitCount - 1) & 7)));
+                output[byteOffset] ^= (byte)(mask & (streamByte ^ TailXor));
+            }
+        }
+    }
+
+    private static ulong TransformUInt64(ulong value, uint state)
+    {
+        unchecked
+        {
+            value = SwapAdjacentBits(~value) ^ ~(ulong)RotateRight(state, 5);
+            value = ~RotateRight(value, (int)(RotateRight(state, 4) % 63) + 1);
+            return value + RotateRight(state, 1);
+        }
+    }
+
+    private static uint TransformUInt32(uint value, uint state)
+    {
+        unchecked
+        {
+            value = SwapAdjacentBits(~value) ^ RotateLeft(state, 5);
+            value = ~RotateRight(value, (int)(RotateLeft(state, 4) % 31) + 1);
+            return value + RotateLeft(state, 1);
+        }
+    }
+
+    private static byte TransformByte(byte value, uint state)
+    {
+        unchecked
+        {
+            var state11 = state * 0x0bu;
+            var mix = state11 * 0x533u;
+            value = (byte)(SwapAdjacentBits((byte)~value) ^ (byte)(mix * 0x0bu));
+            value = (byte)~RotateRight(value, (int)(mix % 7) + 1);
+            return (byte)(value + (byte)state11);
+        }
+    }
+
+    private static ulong InitialPrngA(uint seed)
+    {
+        unchecked
+        {
+            var seedPlus = seed + SeedAddend;
+            var mixed = ((seedPlus >> 15) ^ seedPlus) >> 12 ^
+                        ((seed - InitAOffset) * 0x02000000u) ^
+                        seedPlus;
+            return mixed * Multiplier;
+        }
+    }
+
+}

--- a/src/Replay.Unreal/Bunches/ContentBlockPathResolver.cs
+++ b/src/Replay.Unreal/Bunches/ContentBlockPathResolver.cs
@@ -1,4 +1,5 @@
 ﻿using Replay.Encoding.Net;
+using Replay.Models.Net;
 using Replay.Unreal.Channels;
 using Replay.Unreal.Parsing;
 
@@ -198,8 +199,42 @@ internal sealed class ContentBlockPathResolver
             return true;
         }
 
+        group = UniqueLeafMatch(path);
+        if (group is not null)
+        {
+            exportGroupPath = group.PathName;
+            return true;
+        }
+
         exportGroupPath = string.Empty;
         return false;
+    }
+
+    private NetFieldExportGroup? UniqueLeafMatch(string path)
+    {
+        if (path.IndexOfAny(['/', '.', ':']) >= 0)
+        {
+            return null;
+        }
+
+        NetFieldExportGroup? match = null;
+        var suffix = "." + path;
+        foreach (var candidate in _netGuidCache.ExportGroupsByPath.Values)
+        {
+            if (!candidate.PathName.EndsWith(suffix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (match is not null && !ReferenceEquals(match, candidate))
+            {
+                return null;
+            }
+
+            match = candidate;
+        }
+
+        return match;
     }
 
     private bool TryResolveCandidate(

--- a/src/Replay.Unreal/Parsing/DescriptorCatalogIndex.cs
+++ b/src/Replay.Unreal/Parsing/DescriptorCatalogIndex.cs
@@ -67,6 +67,7 @@ internal sealed class DescriptorCatalogIndex
 
         if (ReplayPath.GetDefaultObjectName(descriptor.Path) is { } defaultObjectName)
         {
+            _exportDescriptorsByPath[defaultObjectName] = descriptor;
             _exportKindsByDefaultObjectName[defaultObjectName] = descriptor.Kind;
         }
     }

--- a/src/Replay.Unreal/Parsing/ReplayPath.cs
+++ b/src/Replay.Unreal/Parsing/ReplayPath.cs
@@ -5,10 +5,17 @@ internal static class ReplayPath
     public const string ClassNetCacheSuffix = "_ClassNetCache";
     private const string CoreSegment = "/_Core/";
     private const string CharactersRoot = "/Game/Characters/";
+    private const string DefaultObjectPrefix = "Default__";
 
     public static IEnumerable<string> LookupKeys(string path)
     {
         yield return path;
+
+        var defaultAlias = TryGetDefaultObjectAlias(path);
+        if (defaultAlias is not null)
+        {
+            yield return defaultAlias;
+        }
 
         var coreAlias = TryGetCoreAlias(path);
         if (coreAlias is not null)
@@ -83,5 +90,17 @@ internal static class ReplayPath
     private static string? TryGetCoreAlias(string path)
     {
         return TryGetAlias(path, out var alias) ? alias : null;
+    }
+
+    private static string? TryGetDefaultObjectAlias(string path)
+    {
+        if (path.StartsWith(DefaultObjectPrefix, StringComparison.Ordinal))
+        {
+            return path[DefaultObjectPrefix.Length..];
+        }
+
+        return path.IndexOfAny(['/', '.', ':']) < 0
+            ? DefaultObjectPrefix + path
+            : null;
     }
 }

--- a/src/Replay.Valorant/Descriptors/Agents/GenericAgentDescriptor.cs
+++ b/src/Replay.Valorant/Descriptors/Agents/GenericAgentDescriptor.cs
@@ -31,10 +31,10 @@ public abstract class GenericAgentDescriptor : ExportGroupDescriptor<GenericAgen
         AddProperty("bReplicateMovement", x => ReplicateMovement).Bool();
         AddProperty(x => Owner).ObjectNetGuid();
         AddProperty(x => Instigator).ObjectNetGuid();
-        AddProperty(x => PlayerState).Byte();
+        AddProperty(x => PlayerState).ObjectNetGuidOrRaw();
         AddProperty(x => Controller).ObjectNetGuid();
         AddProperty(x => ReplayLastTransformUpdateTimeStamp).Ignore();
-        AddProperty(x => ReplicatedGravityDirection).FVector();
+        AddProperty(x => ReplicatedGravityDirection).FVectorOrRaw();
         AddProperty(x => ReplicatedMovementMode).Byte();
         AddProperty("bIsPlayerCharacter", x => IsPlayerCharacter).Bool();
         AddProperty("bCrouchHeld", x => CrouchHeld).Bool();

--- a/src/Replay.Valorant/Descriptors/AresAttributeSetDescriptor.cs
+++ b/src/Replay.Valorant/Descriptors/AresAttributeSetDescriptor.cs
@@ -13,6 +13,7 @@ internal sealed class AresAttributeSetDescriptor : ExportGroupDescriptor<AresAtt
     public float MaxHealth { get; set; }
     public float Shield { get; set; }
     public float MaxShield { get; set; }
+    public float Healing { get; set; }
     public float Damage { get; set; }
     public float BaseValue { get; set; }
     public float CurrentValue { get; set; }
@@ -23,6 +24,7 @@ internal sealed class AresAttributeSetDescriptor : ExportGroupDescriptor<AresAtt
         AddProperty(x => x.MaxHealth, ExportCategory.Ability).Float();
         AddProperty(x => x.Shield, ExportCategory.Ability).Float();
         AddProperty(x => x.MaxShield, ExportCategory.Ability).Float();
+        AddProperty(x => x.Healing, ExportCategory.Ability).FloatOrRaw();
         AddProperty(x => x.Damage, ExportCategory.Ability).Float();
         AddProperty(x => x.BaseValue, ExportCategory.Ability).FloatOrRaw();
         AddProperty(x => x.CurrentValue, ExportCategory.Ability).FloatOrRaw();

--- a/src/Replay.Valorant/Descriptors/BaseReplayControllerDescriptor.cs
+++ b/src/Replay.Valorant/Descriptors/BaseReplayControllerDescriptor.cs
@@ -10,11 +10,13 @@ internal sealed class BaseReplayControllerDescriptor : ExportGroupDescriptor<Bas
     public override ExportCategory Categories => ExportCategory.Movement;
     public override ExportGroupKind Kind => ExportGroupKind.PlayerController;
 
+    public uint PlayerState { get; set; }
     public uint RemoteCharacterUpdatesArray { get; set; }
     public FVector SpawnLocation { get; set; }
 
     protected override void Configure()
     {
+        AddProperty(x => x.PlayerState).ObjectNetGuidOrRaw();
         AddProperty(x => x.RemoteCharacterUpdatesArray);
         AddProperty(x => x.SpawnLocation).FVector();
     }

--- a/src/Replay.Valorant/Descriptors/ValorantDescriptors.cs
+++ b/src/Replay.Valorant/Descriptors/ValorantDescriptors.cs
@@ -70,6 +70,13 @@ public static class ValorantDescriptors
 
         catalog.Add(new AresAbilitySystemComponentDescriptor());
         catalog.Add(new AresAttributeSetDescriptor());
+        catalog.Add(new AbilityRechargeComponentDescriptor());
+        catalog.Add(new AbilityRechargeCooldownComponentDescriptor());
+        catalog.Add(new ResourceComponentDescriptor());
+        catalog.Add(new AbilityResourceComponentDescriptor());
+        catalog.Add(new EquipmentChargeComponentDescriptor());
+        catalog.Add(new SignatureAbilityResourceComponentDescriptor());
+        catalog.Add(new AbilityCooldownComponentDescriptor());
         catalog.Add(new AmmoComponentDescriptor());
         catalog.Add(new AresInventoryDescriptor());
         catalog.Add(new AttachedDamageSectionComponentDescriptor());
@@ -80,6 +87,9 @@ public static class ValorantDescriptors
         catalog.Add(new ChildRegionDamageSectionComponentDescriptor());
         catalog.Add(new EquippableStateMachineComponentDescriptor());
         catalog.Add(new FiringStateComponentDescriptor());
+        catalog.Add(new LightArmorItemDescriptor());
+        catalog.Add(new HeavyArmorItemDescriptor());
+        catalog.Add(new PlasmaArmorItemDescriptor());
         catalog.Add(new RemoteCharacterUpdateDescriptor());
         catalog.Add(new BaseReplayPlayerState());
         catalog.Add(new BaseReplayControllerDescriptor());
@@ -88,6 +98,10 @@ public static class ValorantDescriptors
         catalog.Add(new BaseReplayControllerClassNetCacheDescriptor());
         catalog.Add(new BombGameStateClassNetCacheDescriptor());
         catalog.Add(new AresAbilitySystemComponentClassNetCacheDescriptor());
+        catalog.Add(new ChildDamageSectionClassNetCacheDescriptor());
+        catalog.Add(new AttachedDamageSectionClassNetCacheDescriptor());
+        catalog.Add(new ArmorDamageSectionClassNetCacheDescriptor());
+        catalog.Add(new DamageableComponentClassNetCacheDescriptor());
 
         return catalog;
     }

--- a/src/Replay.Valorant/Descriptors/ValorantPayloadDecoders.cs
+++ b/src/Replay.Valorant/Descriptors/ValorantPayloadDecoders.cs
@@ -15,6 +15,9 @@ internal static class ValorantPayloadDecoders
 
     public static IFieldDecoder RawPayload(string typeName) => new RawPayloadDecoder(typeName);
 
+    public static IFieldDecoder CapturedPayload(string typeName) =>
+        new CapturedPayloadDecoder(typeName);
+
     public static IFieldDecoder PrimitiveOrRaw(IFieldDecoder primitiveDecoder, string typeName) =>
         new PrimitiveOrRawDecoder(primitiveDecoder, typeName);
 
@@ -71,6 +74,27 @@ internal static class ValorantPayloadDecoders
         }
     }
 
+    private sealed class CapturedPayloadDecoder(string typeName) : IFieldDecoder
+    {
+        public DecodedFieldValue Decode(ref FieldDecodeContext context, FBitArchive archive)
+        {
+            var bitCount = checked((int)archive.BitsRemaining);
+            var bytes = new byte[(bitCount + 7) / 8];
+            for (var bit = 0; bit < bitCount; bit++)
+            {
+                if (archive.ReadBit())
+                {
+                    bytes[bit / 8] |= (byte)(1 << (bit % 8));
+                }
+            }
+
+            return DecodedFieldValue.FromObject(new ValorantCapturedPayload(
+                typeName,
+                bitCount,
+                Convert.ToBase64String(bytes)));
+        }
+    }
+
     private sealed class NoParametersRpcDecoder : IRpcDecoder
     {
         public DecodedPayloadResult Decode(ref FieldDecodeContext context, FBitArchive archive)
@@ -115,3 +139,8 @@ public sealed record ValorantRawPayload(string TypeName, int BitCount)
 {
     public override string ToString() => $"{TypeName}({BitCount} bits)";
 }
+
+public sealed record ValorantCapturedPayload(
+    string TypeName,
+    int BitCount,
+    string BitsBase64);

--- a/src/Replay.Valorant/GameState/AresRoundResults.cs
+++ b/src/Replay.Valorant/GameState/AresRoundResults.cs
@@ -1,0 +1,206 @@
+using Replay.Encoding.Archives;
+using Replay.Models.Descriptors;
+using Replay.Unreal.Parsing;
+using Replay.Valorant.Descriptors;
+
+namespace Replay.Valorant.GameState;
+
+public sealed record AresRoundResult(
+    int RoundNumber,
+    string? WinningTeam,
+    AresTeamRole? WinningTeamRole,
+    AresRoundOutcome? RoundResult);
+
+public enum AresTeamRole : byte
+{
+    None = 0,
+    Attacker = 1,
+    Defender = 2,
+    FreeForAll = 3,
+    Any = 4,
+    RoleCount = 5,
+}
+
+public enum AresRoundOutcome : byte
+{
+    Elimination = 0,
+    Defuse = 1,
+    Detonate = 2,
+    TimeExpired = 3,
+    Cheat = 4,
+    Surrendered = 5,
+    RoundOutcomeCount = 6,
+    Invalid = 7,
+}
+
+internal sealed class AresRoundResultsDecoder : IFieldDecoder
+{
+    internal const int MaxRoundCount = 128;
+    private const int MaxFieldsPerUpdate = 4;
+    private const int MaxFieldPayloadBits = 64 * 1024;
+    private const uint WinningTeamHandle = 93;
+    private const uint WinningTeamRoleHandle = 94;
+    private const uint RoundResultHandle = 95;
+    private const uint EliminatedTeamsHandle = 96;
+
+    public DecodedFieldValue Decode(ref FieldDecodeContext context, FBitArchive archive)
+    {
+        if (archive.AtEnd) return DecodedFieldValue.FromObject(Array.Empty<AresRoundResult>());
+
+        var roundCount = ReadRoundCount(archive);
+        var results = ReadUpdates(archive, roundCount);
+        archive.EnsureFullyConsumed(nameof(AresRoundResultsDecoder));
+        return DecodedFieldValue.FromObject(results);
+    }
+
+    private static int ReadRoundCount(FBitArchive archive)
+    {
+        var count = archive.ReadIntPacked();
+        if (count <= MaxRoundCount) return (int)count;
+
+        throw InvalidCount(archive, count, $"RoundResults declared {count} rounds; maximum is {MaxRoundCount}.");
+    }
+
+    private static AresRoundResult[] ReadUpdates(FBitArchive archive, int roundCount)
+    {
+        var results = new List<AresRoundResult>();
+        while (ReadUpdateIndex(archive, roundCount) is { } roundNumber)
+        {
+            results.Add(ReadUpdate(archive, roundNumber));
+        }
+
+        return results.ToArray();
+    }
+
+    private static int? ReadUpdateIndex(FBitArchive archive, int roundCount)
+    {
+        var encodedIndex = archive.ReadIntPacked();
+        if (encodedIndex == 0) return null;
+
+        var roundNumber = checked((int)encodedIndex - 1);
+        if (roundNumber < roundCount) return roundNumber;
+
+        throw InvalidCount(archive, encodedIndex, $"RoundResults update index {roundNumber} exceeds count {roundCount}.");
+    }
+
+    private static AresRoundResult ReadUpdate(FBitArchive archive, int roundNumber)
+    {
+        string? winningTeam = null;
+        AresTeamRole? winningTeamRole = null;
+        AresRoundOutcome? roundResult = null;
+
+        for (var fieldCount = 0; fieldCount <= MaxFieldsPerUpdate; fieldCount++)
+        {
+            var encodedHandle = archive.ReadIntPacked();
+            if (encodedHandle == 0)
+            {
+                return new AresRoundResult(roundNumber, winningTeam, winningTeamRole, roundResult);
+            }
+
+            if (fieldCount == MaxFieldsPerUpdate) throw TooManyFields(archive);
+            ReadField(archive, encodedHandle - 1, ref winningTeam, ref winningTeamRole, ref roundResult);
+        }
+
+        throw TooManyFields(archive);
+    }
+
+    private static void ReadField(
+        FBitArchive archive,
+        uint handle,
+        ref string? winningTeam,
+        ref AresTeamRole? winningTeamRole,
+        ref AresRoundOutcome? roundResult)
+    {
+        var field = ReadFieldPayload(archive);
+        switch (handle)
+        {
+            case WinningTeamHandle:
+                winningTeam = field.ReadFName();
+                break;
+            case WinningTeamRoleHandle:
+                winningTeamRole = (AresTeamRole)ReadEnum(field);
+                break;
+            case RoundResultHandle:
+                roundResult = (AresRoundOutcome)ReadEnum(field);
+                break;
+            case EliminatedTeamsHandle:
+                field.SkipRemaining();
+                break;
+            default:
+                throw new UnsupportedRoundResultsLayoutException(handle);
+        }
+
+        field.EnsureFullyConsumed($"FAresRoundResult field {handle}");
+    }
+
+    private static FBitArchive ReadFieldPayload(FBitArchive archive)
+    {
+        var bitCount = archive.ReadIntPacked();
+        if (bitCount <= MaxFieldPayloadBits && bitCount <= archive.BitsRemaining)
+        {
+            return archive.ReadSubArchive((int)bitCount);
+        }
+
+        throw new ArchiveReadException(
+            ArchiveErrorCode.InvalidBitCount,
+            nameof(AresRoundResultsDecoder),
+            archive.Position,
+            archive.Length,
+            bitCount);
+    }
+
+    private static byte ReadEnum(FBitArchive archive)
+    {
+        if (archive.BitsRemaining is > 0 and <= 8)
+        {
+            return (byte)archive.ReadBitsToUInt64((int)archive.BitsRemaining);
+        }
+
+        throw new ArchiveReadException(
+            ArchiveErrorCode.InvalidBitCount,
+            nameof(AresRoundResultsDecoder),
+            archive.Position,
+            archive.Length,
+            archive.BitsRemaining);
+    }
+
+    private static ArchiveReadException TooManyFields(FBitArchive archive) =>
+        InvalidCount(archive, MaxFieldsPerUpdate + 1, "FAresRoundResult contains too many fields.");
+
+    private static ArchiveReadException InvalidCount(FBitArchive archive, long requested, string message) =>
+        new(
+            ArchiveErrorCode.InvalidCount,
+            nameof(AresRoundResultsDecoder),
+            archive.Position,
+            archive.Length,
+            requested,
+            message);
+}
+
+internal sealed class CompatibleAresRoundResultsDecoder : IFieldDecoder
+{
+    private readonly AresRoundResultsDecoder _release1301 = new();
+
+    public DecodedFieldValue Decode(ref FieldDecodeContext context, FBitArchive archive)
+    {
+        using (var checkpoint = archive.CreateCheckpoint())
+        {
+            try
+            {
+                var value = _release1301.Decode(ref context, archive);
+                checkpoint.Commit();
+                return value;
+            }
+            catch (UnsupportedRoundResultsLayoutException)
+            {
+            }
+        }
+
+        var bitCount = checked((int)archive.BitsRemaining);
+        archive.SkipRemaining();
+        return DecodedFieldValue.FromObject(new ValorantRawPayload("TArray<FAresRoundResult>", bitCount));
+    }
+}
+
+internal sealed class UnsupportedRoundResultsLayoutException(uint handle)
+    : Exception($"Unknown FAresRoundResult field handle {handle}.");

--- a/src/Replay.Valorant/GameState/AresTeamEconomy.cs
+++ b/src/Replay.Valorant/GameState/AresTeamEconomy.cs
@@ -1,0 +1,125 @@
+using Replay.Encoding.Archives;
+using Replay.Models.Descriptors;
+using Replay.Unreal.Parsing;
+using Replay.Valorant.Descriptors;
+
+namespace Replay.Valorant.GameState;
+
+public sealed record AresTeamEconomyUpdate(
+    int Index,
+    uint? ReplicationId,
+    int? LoadoutValue,
+    int? AverageLoadoutValue);
+
+internal sealed class AresTeamEconomyDecoder : IFieldDecoder
+{
+    private const int MaxTeams = 8;
+    private const int MaxFields = 4;
+    private const int MaxFieldPayloadBits = 64 * 1024;
+
+    public DecodedFieldValue Decode(ref FieldDecodeContext context, FBitArchive archive)
+    {
+        var count = checked((int)archive.ReadIntPacked());
+        if (count > MaxTeams) throw InvalidCount(archive, count);
+        var values = ReadUpdates(archive, count);
+        archive.EnsureFullyConsumed(nameof(AresTeamEconomyDecoder));
+        return DecodedFieldValue.FromObject(values);
+    }
+
+    private static AresTeamEconomyUpdate[] ReadUpdates(FBitArchive archive, int count)
+    {
+        var result = new List<AresTeamEconomyUpdate>();
+        while (ReadIndex(archive, count) is { } index)
+        {
+            result.Add(ReadUpdate(archive, index));
+        }
+        return result.ToArray();
+    }
+
+    private static int? ReadIndex(FBitArchive archive, int count)
+    {
+        var encoded = archive.ReadIntPacked();
+        if (encoded == 0) return null;
+        var index = checked((int)encoded - 1);
+        if (index < count) return index;
+        throw InvalidCount(archive, encoded);
+    }
+
+    private static AresTeamEconomyUpdate ReadUpdate(FBitArchive archive, int index)
+    {
+        uint? replicationId = null;
+        int? loadout = null;
+        int? average = null;
+        for (var count = 0; count < MaxFields; count++)
+        {
+            var encoded = archive.ReadIntPacked();
+            if (encoded == 0)
+            {
+                return new(index, replicationId, loadout, average);
+            }
+            using var field = ReadField(archive);
+            switch (encoded - 1)
+            {
+                case 56: replicationId = field.ReadIntPacked(); break;
+                case 57: loadout = field.ReadInt32(); break;
+                case 58: average = field.ReadInt32(); break;
+                default: throw new UnsupportedTeamEconomyLayoutException(encoded - 1);
+            }
+            field.EnsureFullyConsumed($"FAresTeamEconomy field {encoded - 1}");
+        }
+        throw InvalidCount(archive, MaxFields);
+    }
+
+    private static FBitArchive ReadField(FBitArchive archive)
+    {
+        var bits = archive.ReadIntPacked();
+        if (bits <= MaxFieldPayloadBits && bits <= archive.BitsRemaining)
+        {
+            return archive.ReadSubArchive(checked((int)bits));
+        }
+        throw new ArchiveReadException(
+            ArchiveErrorCode.InvalidBitCount,
+            nameof(AresTeamEconomyDecoder),
+            archive.Position,
+            archive.Length,
+            bits);
+    }
+
+    private static ArchiveReadException InvalidCount(FBitArchive archive, long count) =>
+        new(
+            ArchiveErrorCode.InvalidCount,
+            nameof(AresTeamEconomyDecoder),
+            archive.Position,
+            archive.Length,
+            count);
+}
+
+internal sealed class CompatibleAresTeamEconomyDecoder : IFieldDecoder
+{
+    private readonly AresTeamEconomyDecoder _decoder = new();
+    private readonly IFieldDecoder _fallback =
+        ValorantPayloadDecoders.RawPayload("TArray<FAresTeamEconomy>");
+
+    public DecodedFieldValue Decode(ref FieldDecodeContext context, FBitArchive archive)
+    {
+        using (var checkpoint = archive.CreateCheckpoint())
+        {
+            try
+            {
+                var value = _decoder.Decode(ref context, archive);
+                checkpoint.Commit();
+                return value;
+            }
+            catch (ArchiveReadException)
+            {
+            }
+            catch (UnsupportedTeamEconomyLayoutException)
+            {
+            }
+        }
+        return _fallback.Decode(ref context, archive);
+    }
+}
+
+internal sealed class UnsupportedTeamEconomyLayoutException(uint handle)
+    : Exception($"Unknown FAresTeamEconomy field handle {handle}.");

--- a/src/Replay.Valorant/GameState/BombGameplayDescriptors.cs
+++ b/src/Replay.Valorant/GameState/BombGameplayDescriptors.cs
@@ -48,7 +48,7 @@ internal sealed class BombGameStateDescriptor : ExportGroupDescriptor<BombGameSt
     public string? MatchState { get; set; }
     public uint WinningTeam { get; set; }
     public byte CompletionState { get; set; }
-    public ValorantRawPayload? TeamEconomy { get; set; }
+    public object? TeamEconomy { get; set; }
     public float DisplayRemainingTime { get; set; }
     public float StateRemainingTime { get; set; }
     public float GamePhaseElapsedTime { get; set; }
@@ -56,7 +56,7 @@ internal sealed class BombGameStateDescriptor : ExportGroupDescriptor<BombGameSt
     public float AuthGameplayEndTimestamp { get; set; }
     public int NetServerMaxTickRate { get; set; }
     public string? MatchID { get; set; }
-    public ValorantRawPayload? RoundResults { get; set; }
+    public object? RoundResults { get; set; }
     public byte Phase { get; set; }
     public ValorantRawPayload? RoundParticipantsInfos { get; set; }
     public int RoundNumber { get; set; }
@@ -68,7 +68,7 @@ internal sealed class BombGameStateDescriptor : ExportGroupDescriptor<BombGameSt
         AddProperty(x => x.MatchState).FNameOrRaw();
         AddProperty(x => x.WinningTeam).ObjectNetGuidOrRaw();
         AddProperty(x => x.CompletionState).EnumByteOrRaw();
-        AddProperty(x => x.TeamEconomy).Decode(ValorantPayloadDecoders.RawPayload("TArray<FAresTeamEconomy>"));
+        AddProperty(x => x.TeamEconomy).Decode(new CompatibleAresTeamEconomyDecoder());
         AddProperty(x => x.DisplayRemainingTime).FloatOrRaw();
         AddProperty(x => x.StateRemainingTime).FloatOrRaw();
         AddProperty(x => x.GamePhaseElapsedTime).FloatOrRaw();
@@ -76,7 +76,7 @@ internal sealed class BombGameStateDescriptor : ExportGroupDescriptor<BombGameSt
         AddProperty(x => x.AuthGameplayEndTimestamp).FloatOrRaw();
         AddProperty(x => x.NetServerMaxTickRate).Int32OrRaw();
         AddProperty(x => x.MatchID).FStringOrRaw();
-        AddProperty(x => x.RoundResults).Decode(ValorantPayloadDecoders.RawPayload("TArray<FAresRoundResult>"));
+        AddProperty(x => x.RoundResults).Decode(new CompatibleAresRoundResultsDecoder());
         AddProperty(x => x.Phase).EnumByteOrRaw();
         AddProperty(x => x.RoundParticipantsInfos)
             .Decode(ValorantPayloadDecoders.RawPayload("TArray<FRoundParticipantsInfo>"));
@@ -91,7 +91,7 @@ internal sealed class BombCombatReportComponentDescriptor : ExportGroupDescripto
     public override ExportCategory Categories => ExportCategory.GameState | ExportCategory.Gunplay;
     public override ExportGroupKind Kind => ExportGroupKind.Component;
 
-    public ValorantRawPayload? Rounds { get; set; }
+    public object? Rounds { get; set; }
     public int RoundNum { get; set; }
     public ValorantRawPayload? Reports { get; set; }
     public int RoundNumber { get; set; }
@@ -127,7 +127,7 @@ internal sealed class BombCombatReportComponentDescriptor : ExportGroupDescripto
 
     protected override void Configure()
     {
-        AddProperty(x => x.Rounds).Decode(ValorantPayloadDecoders.RawPayload("TArray<FRoundReports>"));
+        AddProperty(x => x.Rounds).Decode(new CompatibleCombatRoundReportsDecoder());
         AddProperty(x => x.RoundNum).Int32OrRaw();
         AddProperty(x => x.Reports).Decode(ValorantPayloadDecoders.RawPayload("TArray<FCharacterCombatReport>"));
         AddProperty(x => x.RoundNumber).Int32OrRaw();
@@ -231,11 +231,13 @@ internal sealed class ChildDamageSectionComponentDescriptor
     public override ExportGroupKind Kind => ExportGroupKind.Component;
 
     public bool Alive { get; set; }
+    public float Life { get; set; }
     public float MaximumLife { get; set; }
 
     protected override void Configure()
     {
         AddProperty("bAlive", x => x.Alive).BoolOrRaw();
+        AddProperty(x => x.Life).FloatOrRaw();
         AddProperty(x => x.MaximumLife).FloatOrRaw();
     }
 }
@@ -248,10 +250,14 @@ internal sealed class ChildRegionDamageSectionComponentDescriptor
     public override ExportGroupKind Kind => ExportGroupKind.Component;
 
     public bool Alive { get; set; }
+    public float Life { get; set; }
+    public float MaximumLife { get; set; }
 
     protected override void Configure()
     {
         AddProperty("bAlive", x => x.Alive).BoolOrRaw();
+        AddProperty(x => x.Life).FloatOrRaw();
+        AddProperty(x => x.MaximumLife).FloatOrRaw();
     }
 }
 
@@ -263,10 +269,14 @@ internal sealed class AttachedDamageSectionComponentDescriptor
     public override ExportGroupKind Kind => ExportGroupKind.Component;
 
     public bool Alive { get; set; }
+    public float Life { get; set; }
+    public float MaximumLife { get; set; }
 
     protected override void Configure()
     {
         AddProperty("bAlive", x => x.Alive).BoolOrRaw();
+        AddProperty(x => x.Life).FloatOrRaw();
+        AddProperty(x => x.MaximumLife).FloatOrRaw();
     }
 }
 

--- a/src/Replay.Valorant/GameState/CombatResourceDescriptors.cs
+++ b/src/Replay.Valorant/GameState/CombatResourceDescriptors.cs
@@ -1,0 +1,186 @@
+using Replay.Models.Descriptors;
+using Replay.Valorant.Descriptors;
+
+namespace Replay.Valorant.GameState;
+
+internal sealed class AbilityRechargeComponentDescriptor
+    : ExportGroupDescriptor<AbilityRechargeComponentDescriptor>
+{
+    public override string Path => "/Script/ShooterGame.AbilityRechargeComponent";
+    public override ExportCategory Categories => ExportCategory.Ability;
+    public override ExportGroupKind Kind => ExportGroupKind.Component;
+
+    public int MaxCharges { get; set; }
+    public int CurrentCharges { get; set; }
+
+    protected override void Configure()
+    {
+        AddProperty(x => x.MaxCharges).Int32OrRaw();
+        AddProperty(x => x.CurrentCharges).Int32OrRaw();
+    }
+}
+
+internal sealed class AbilityRechargeCooldownComponentDescriptor
+    : ExportGroupDescriptor<AbilityRechargeCooldownComponentDescriptor>
+{
+    public override string Path => "/Script/ShooterGame.AbilityRechargeCooldownComponent";
+    public override ExportCategory Categories => ExportCategory.Ability;
+    public override ExportGroupKind Kind => ExportGroupKind.Component;
+
+    public float CooldownSeconds { get; set; }
+    public float TempChargeCooldownSeconds { get; set; }
+    public float CooldownFinishTimestamp { get; set; }
+    public float TempChargeCooldownFinishTimestamp { get; set; }
+    public int ChargesInUse { get; set; }
+    public bool CooldownPaused { get; set; }
+
+    protected override void Configure()
+    {
+        AddProperty(x => x.CooldownSeconds).FloatOrRaw();
+        AddProperty(x => x.TempChargeCooldownSeconds).FloatOrRaw();
+        AddProperty(x => x.CooldownFinishTimestamp).FloatOrRaw();
+        AddProperty(x => x.TempChargeCooldownFinishTimestamp).FloatOrRaw();
+        AddProperty(x => x.ChargesInUse).Int32OrRaw();
+        AddProperty("bCooldownPaused", x => x.CooldownPaused).BoolOrRaw();
+    }
+}
+
+internal class ResourceComponentDescriptor<TDescriptor> : ExportGroupDescriptor<TDescriptor>
+    where TDescriptor : ResourceComponentDescriptor<TDescriptor>
+{
+    public override ExportCategory Categories => ExportCategory.Ability | ExportCategory.Inventory;
+    public override ExportGroupKind Kind => ExportGroupKind.Component;
+
+    public int AuthResourceAmount { get; set; }
+    public int PredictedResourceAmount { get; set; }
+
+    protected override void Configure()
+    {
+        AddProperty(x => x.AuthResourceAmount).Int32OrRaw();
+        AddProperty(x => x.PredictedResourceAmount).Int32OrRaw();
+    }
+}
+
+internal sealed class ResourceComponentDescriptor
+    : ResourceComponentDescriptor<ResourceComponentDescriptor>
+{
+    public override string Path => "/Script/ShooterGame.ResourceComponent";
+}
+
+internal sealed class AbilityResourceComponentDescriptor
+    : ResourceComponentDescriptor<AbilityResourceComponentDescriptor>
+{
+    public override string Path => "/Script/ShooterGame.AbilityResourceComponent";
+}
+
+internal sealed class EquipmentChargeComponentDescriptor
+    : ResourceComponentDescriptor<EquipmentChargeComponentDescriptor>
+{
+    public override string Path => "/Script/ShooterGame.EquipmentChargeComponent";
+
+    public int MaxCharges { get; set; }
+    public int ChargesBoughtThisRound { get; set; }
+    public int CurrentTemporaryCharges { get; set; }
+    public int TotalChargesAllowedToPurchaseThisRound { get; set; }
+
+    protected override void Configure()
+    {
+        base.Configure();
+        AddProperty(x => x.MaxCharges).Int32OrRaw();
+        AddProperty(x => x.ChargesBoughtThisRound).Int32OrRaw();
+        AddProperty(x => x.CurrentTemporaryCharges).Int32OrRaw();
+        AddProperty(x => x.TotalChargesAllowedToPurchaseThisRound).Int32OrRaw();
+    }
+}
+
+internal sealed class SignatureAbilityResourceComponentDescriptor
+    : ResourceComponentDescriptor<SignatureAbilityResourceComponentDescriptor>
+{
+    public override string Path => "/Script/ShooterGame.SignatureAbilityResourceComponent";
+
+    public int ChargesBoughtThisRound { get; set; }
+    public int CurrentTemporaryCharges { get; set; }
+    public int TotalChargesAllowedToPurchaseThisRound { get; set; }
+    public int AuthSignatureChargeAmount { get; set; }
+
+    protected override void Configure()
+    {
+        base.Configure();
+        AddProperty(x => x.ChargesBoughtThisRound).Int32OrRaw();
+        AddProperty(x => x.CurrentTemporaryCharges).Int32OrRaw();
+        AddProperty(x => x.TotalChargesAllowedToPurchaseThisRound).Int32OrRaw();
+        AddProperty(x => x.AuthSignatureChargeAmount).Int32OrRaw();
+    }
+}
+
+internal sealed class AbilityCooldownComponentDescriptor
+    : ExportGroupDescriptor<AbilityCooldownComponentDescriptor>
+{
+    public override string Path =>
+        "/Game/Characters/Components/Comp_Ability_CooldownComponent.Comp_Ability_CooldownComponent_C";
+    public override ExportCategory Categories => ExportCategory.Ability;
+    public override ExportGroupKind Kind => ExportGroupKind.Component;
+
+    public float CooldownSeconds { get; set; }
+    public float StartTimeStamp { get; set; }
+    public bool CooldownActive { get; set; }
+
+    protected override void Configure()
+    {
+        AddProperty(x => x.CooldownSeconds).FloatOrRaw();
+        AddProperty(x => x.StartTimeStamp).FloatOrRaw();
+        AddProperty(x => x.CooldownActive).BoolOrRaw();
+    }
+}
+
+internal abstract class ArmorItemDescriptor<TDescriptor> : ExportGroupDescriptor<TDescriptor>
+    where TDescriptor : ArmorItemDescriptor<TDescriptor>
+{
+    public override ExportCategory Categories => ExportCategory.Inventory | ExportCategory.Gunplay;
+    public override ExportGroupKind Kind => ExportGroupKind.Actor;
+
+    public int MaximumAmount { get; set; }
+    public uint Owner { get; set; }
+    public uint MyPawn { get; set; }
+    public byte InInventory { get; set; }
+    public uint AttachedDamageSection { get; set; }
+
+    protected override void Configure()
+    {
+        AddProperty(x => x.MaximumAmount).Int32OrRaw();
+        AddProperty(x => x.Owner).ObjectNetGuidOrRaw();
+        AddProperty(x => x.MyPawn).ObjectNetGuidOrRaw();
+        AddProperty(x => x.InInventory).EnumByteOrRaw();
+        AddProperty(x => x.AttachedDamageSection).ObjectNetGuidOrRaw();
+    }
+}
+
+internal sealed class LightArmorItemDescriptor
+    : ArmorItemDescriptor<LightArmorItemDescriptor>
+{
+    public override string Path => "/Game/Gear/LightArmorItem.LightArmorItem_C";
+}
+
+internal sealed class HeavyArmorItemDescriptor
+    : ArmorItemDescriptor<HeavyArmorItemDescriptor>
+{
+    public override string Path => "/Game/Gear/HeavyArmorItem.HeavyArmorItem_C";
+}
+
+internal sealed class PlasmaArmorItemDescriptor
+    : ArmorItemDescriptor<PlasmaArmorItemDescriptor>
+{
+    public override string Path => "/Game/Gear/PlasmaArmor/PlasmaArmorItem.PlasmaArmorItem_C";
+
+    public bool RegenActive { get; set; }
+    public double MaxRegenPool { get; set; }
+    public double CurrentRegenPool { get; set; }
+
+    protected override void Configure()
+    {
+        base.Configure();
+        AddProperty(x => x.RegenActive).BoolOrRaw();
+        AddProperty(x => x.MaxRegenPool).DoubleOrRaw();
+        AddProperty(x => x.CurrentRegenPool).DoubleOrRaw();
+    }
+}

--- a/src/Replay.Valorant/GameState/CombatRoundReports.cs
+++ b/src/Replay.Valorant/GameState/CombatRoundReports.cs
@@ -1,0 +1,330 @@
+using Replay.Encoding.Archives;
+using Replay.Models.Descriptors;
+using Replay.Unreal.Parsing;
+using Replay.Valorant.Descriptors;
+
+namespace Replay.Valorant.GameState;
+
+public sealed record CombatRoundReportUpdate(
+    int Index,
+    int? RoundNumber,
+    IReadOnlyList<CharacterCombatReportUpdate> Reports);
+
+public sealed record CharacterCombatReportUpdate(
+    int Index,
+    int? RoundNumber,
+    IReadOnlyList<ParticipantInteractionUpdate> Interactions,
+    uint? ResurrectorPlayerState,
+    bool? Died);
+
+public sealed record ParticipantInteractionUpdate(
+    int Index,
+    string? Subject,
+    string? Team,
+    uint? CharacterIcon,
+    float? DamageDealt,
+    int? HitsDealt,
+    float? DamageReceived,
+    int? HitsReceived,
+    bool? DidKill,
+    byte? AssistType,
+    uint? KillerPlayerState,
+    bool? WasKiller,
+    int? CombatReportIndex,
+    IReadOnlyList<CombatInteractionUpdate> DealtInteractions,
+    IReadOnlyList<CombatInteractionUpdate> ReceivedInteractions,
+    IReadOnlyList<uint> DestroyedArmor);
+
+public sealed record CombatInteractionUpdate(
+    int Index,
+    uint? DamageType,
+    IReadOnlyList<RegionalDamageInteractionUpdate> Regions);
+
+public sealed record RegionalDamageInteractionUpdate(
+    int Index,
+    byte? Region,
+    int? Hits,
+    float? Damage,
+    bool? IsWallPen,
+    bool? IsKill,
+    uint? DestroyedArmor);
+
+internal sealed class CompatibleCombatRoundReportsDecoder : IFieldDecoder
+{
+    private readonly CombatRoundReportsDecoder _decoder = new();
+    private readonly IFieldDecoder _fallback =
+        ValorantPayloadDecoders.CapturedPayload("TArray<FRoundReports>");
+
+    public DecodedFieldValue Decode(ref FieldDecodeContext context, FBitArchive archive)
+    {
+        using (var checkpoint = archive.CreateCheckpoint())
+        {
+            try
+            {
+                var value = _decoder.Decode(ref context, archive);
+                checkpoint.Commit();
+                return value;
+            }
+            catch (ArchiveReadException)
+            {
+            }
+            catch (OverflowException)
+            {
+            }
+        }
+        return _fallback.Decode(ref context, archive);
+    }
+}
+
+public sealed class CombatRoundReportsDecoder : IFieldDecoder
+{
+    private const int MaxItems = 256;
+    private const int MaxFields = 128;
+    private const int MaxFieldPayloadBits = 256 * 1024;
+
+    public DecodedFieldValue Decode(ref FieldDecodeContext context, FBitArchive archive)
+    {
+        var reports = ReadArray(archive, ReadRound);
+        archive.EnsureFullyConsumed(nameof(CombatRoundReportsDecoder));
+        return DecodedFieldValue.FromObject(reports);
+    }
+
+    private static CombatRoundReportUpdate ReadRound(int index, FBitArchive archive)
+    {
+        int? roundNumber = null;
+        IReadOnlyList<CharacterCombatReportUpdate> reports = [];
+        ReadFields(archive, (handle, field) =>
+        {
+            if (handle == 3) roundNumber = ReadInt32(field);
+            if (handle == 4) reports = ReadArray(field, ReadCharacterReport);
+        });
+        return new CombatRoundReportUpdate(index, roundNumber, reports);
+    }
+
+    private static CharacterCombatReportUpdate ReadCharacterReport(int index, FBitArchive archive)
+    {
+        int? roundNumber = null;
+        IReadOnlyList<ParticipantInteractionUpdate> interactions = [];
+        uint? resurrector = null;
+        bool? died = null;
+        ReadFields(archive, (handle, field) =>
+        {
+            if (handle == 5) roundNumber = ReadInt32(field);
+            if (handle == 10) interactions = ReadArray(field, ReadParticipant);
+            if (handle == 98) resurrector = ReadNetGuid(field);
+            if (handle == 103) died = ReadBool(field);
+        });
+        return new CharacterCombatReportUpdate(index, roundNumber, interactions, resurrector, died);
+    }
+
+    private static ParticipantInteractionUpdate ReadParticipant(int index, FBitArchive archive)
+    {
+        var state = new ParticipantState(index);
+        ReadFields(archive, state.Read);
+        return state.Build();
+    }
+
+    private static IReadOnlyList<CombatInteractionUpdate> ReadCombatInteractions(
+        FBitArchive archive,
+        int regionsHandle,
+        int regionHandle)
+    {
+        return ReadArray(archive, (index, item) =>
+        {
+            uint? damageType = null;
+            IReadOnlyList<RegionalDamageInteractionUpdate> regions = [];
+            ReadFields(item, (handle, field) =>
+            {
+                if (handle == regionsHandle)
+                {
+                    regions = ReadRegionalInteractions(field, regionHandle);
+                }
+            });
+            return new CombatInteractionUpdate(index, damageType, regions);
+        });
+    }
+
+    private static IReadOnlyList<RegionalDamageInteractionUpdate> ReadRegionalInteractions(
+        FBitArchive archive,
+        int regionHandle)
+    {
+        return ReadArray(archive, (index, item) =>
+        {
+            byte? region = null;
+            int? hits = null;
+            float? damage = null;
+            bool? wallPen = null;
+            bool? kill = null;
+            uint? armor = null;
+            ReadFields(item, (handle, field) =>
+            {
+                if (handle == regionHandle) region = TryRead(field, ReadByte);
+                if (handle == regionHandle + 1) hits = TryRead(field, ReadInt32);
+                if (handle == regionHandle + 2) damage = TryRead(field, ReadFloat);
+                if (handle == regionHandle + 3) wallPen = TryRead(field, ReadBool);
+                if (handle == regionHandle + 4) kill = TryRead(field, ReadBool);
+                if (handle == regionHandle + 5) armor = TryRead(field, ReadNetGuid);
+            });
+            return new RegionalDamageInteractionUpdate(
+                index, region, hits, damage, wallPen, kill, armor);
+        });
+    }
+
+    private static T[] ReadArray<T>(FBitArchive archive, Func<int, FBitArchive, T> readItem)
+    {
+        var declaredCount = ReadCount(archive);
+        var updates = new List<T>();
+        while (ReadIndex(archive, declaredCount) is { } index)
+        {
+            updates.Add(readItem(index, archive));
+        }
+        return updates.ToArray();
+    }
+
+    private static void ReadFields(FBitArchive archive, Action<int, FBitArchive> readField)
+    {
+        for (var count = 0; count < MaxFields; count++)
+        {
+            var encodedHandle = archive.ReadIntPacked();
+            if (encodedHandle == 0) return;
+            using var field = ReadFieldPayload(archive);
+            readField(checked((int)encodedHandle - 1), field);
+            field.SkipRemaining();
+        }
+        throw InvalidCount(archive, MaxFields, "Combat report contains too many fields.");
+    }
+
+    private static FBitArchive ReadFieldPayload(FBitArchive archive)
+    {
+        var bitCount = archive.ReadIntPacked();
+        if (bitCount <= MaxFieldPayloadBits && bitCount <= archive.BitsRemaining)
+        {
+            return archive.ReadSubArchive(checked((int)bitCount));
+        }
+        throw InvalidCount(archive, bitCount, "Invalid combat report field bit count.");
+    }
+
+    private static int ReadCount(FBitArchive archive)
+    {
+        var count = archive.ReadIntPacked();
+        if (count <= MaxItems) return checked((int)count);
+        throw InvalidCount(archive, count, "Combat report array is too large.");
+    }
+
+    private static int? ReadIndex(FBitArchive archive, int declaredCount)
+    {
+        var encodedIndex = archive.ReadIntPacked();
+        if (encodedIndex == 0) return null;
+        var index = checked((int)encodedIndex - 1);
+        if (index < declaredCount) return index;
+        throw InvalidCount(archive, encodedIndex, "Combat report update index exceeds array size.");
+    }
+
+    private static int ReadInt32(FBitArchive archive) => archive.ReadInt32();
+    private static float ReadFloat(FBitArchive archive) => archive.ReadSingle();
+    private static bool ReadBool(FBitArchive archive) => archive.ReadBit();
+    private static byte ReadByte(FBitArchive archive) =>
+        checked((byte)archive.ReadBitsToUInt64(checked((int)archive.BitsRemaining)));
+    private static uint ReadNetGuid(FBitArchive archive) => archive.ReadIntPacked();
+    private static string ReadString(FBitArchive archive) => archive.ReadFString();
+    private static string ReadName(FBitArchive archive) => archive.ReadFName();
+
+    private static T? TryRead<T>(FBitArchive archive, Func<FBitArchive, T> read)
+        where T : struct
+    {
+        using var checkpoint = archive.CreateCheckpoint();
+        try
+        {
+            var value = read(archive);
+            if (!archive.AtEnd) return null;
+            checkpoint.Commit();
+            return value;
+        }
+        catch (ArchiveReadException)
+        {
+            return null;
+        }
+        catch (OverflowException)
+        {
+            return null;
+        }
+    }
+
+    private static ArchiveReadException InvalidCount(
+        FBitArchive archive,
+        long requested,
+        string message) =>
+        new(
+            ArchiveErrorCode.InvalidCount,
+            nameof(CombatRoundReportsDecoder),
+            archive.Position,
+            archive.Length,
+            requested,
+            message);
+
+    private sealed class ParticipantState(int index)
+    {
+        private IReadOnlyList<CombatInteractionUpdate> _dealtInteractions = [];
+        private IReadOnlyList<CombatInteractionUpdate> _receivedInteractions = [];
+        private string? _subject;
+        private string? _team;
+        private uint? _characterIcon;
+        private float? _damageDealt;
+        private int? _hitsDealt;
+        private float? _damageReceived;
+        private int? _hitsReceived;
+        private bool? _didKill;
+        private byte? _assistType;
+        private uint? _killerPlayerState;
+        private bool? _wasKiller;
+        private int? _combatReportIndex;
+
+        public void Read(int handle, FBitArchive field)
+        {
+            switch (handle)
+            {
+                case 11: _subject = ReadString(field); break;
+                case 12: _team = ReadName(field); break;
+                case 13: _characterIcon = ReadNetGuid(field); break;
+                case 18: _damageDealt = ReadFloat(field); break;
+                case 19: _hitsDealt = ReadInt32(field); break;
+                case 20: _damageReceived = ReadFloat(field); break;
+                case 21: _hitsReceived = ReadInt32(field); break;
+                case 22: _didKill = ReadBool(field); break;
+                case 23: _assistType = ReadByte(field); break;
+                case 24: _killerPlayerState = ReadNetGuid(field); break;
+                case 25: _wasKiller = ReadBool(field); break;
+                case 26: _dealtInteractions = ReadCombatInteractions(field, 44, 45); break;
+                case 61: _receivedInteractions = ReadCombatInteractions(field, 79, 80); break;
+                case 96: _combatReportIndex = ReadInt32(field); break;
+            }
+        }
+
+        public ParticipantInteractionUpdate Build()
+        {
+            var armor = _dealtInteractions
+                .Concat(_receivedInteractions)
+                .SelectMany(interaction => interaction.Regions)
+                .Where(region => region.DestroyedArmor.HasValue)
+                .Select(region => region.DestroyedArmor!.Value)
+                .ToArray();
+            return new(
+                index,
+                _subject,
+                _team,
+                _characterIcon,
+                _damageDealt,
+                _hitsDealt,
+                _damageReceived,
+                _hitsReceived,
+                _didKill,
+                _assistType,
+                _killerPlayerState,
+                _wasKiller,
+                _combatReportIndex,
+                _dealtInteractions,
+                _receivedInteractions,
+                armor);
+        }
+    }
+}

--- a/src/Replay.Valorant/GameState/DamageClassNetCacheDescriptors.cs
+++ b/src/Replay.Valorant/GameState/DamageClassNetCacheDescriptors.cs
@@ -1,0 +1,158 @@
+using Replay.Models.Descriptors;
+using Replay.Valorant.Descriptors;
+
+namespace Replay.Valorant.GameState;
+
+internal sealed class ChildDamageSectionClassNetCacheDescriptor
+    : ClassNetCacheDescriptor<ChildDamageSectionClassNetCacheDescriptor>
+{
+    public override string Path => "/Script/ShooterGame.ChildDamageSectionComponent_ClassNetCache";
+
+    protected override void Configure()
+    {
+        AddFunction<MulticastNotifySetLifeParameters>(
+            "MulticastNotifySetLife",
+            "/Script/ShooterGame.DamageSectionComponent:MulticastNotifySetLife",
+            ExportCategory.Gunplay);
+    }
+}
+
+internal sealed class AttachedDamageSectionClassNetCacheDescriptor
+    : ClassNetCacheDescriptor<AttachedDamageSectionClassNetCacheDescriptor>
+{
+    public override string Path => "/Script/ShooterGame.AttachedDamageSectionComponent_ClassNetCache";
+
+    protected override void Configure()
+    {
+        AddFunction<MulticastNotifySetLifeParameters>(
+            "MulticastNotifySetLife",
+            "/Script/ShooterGame.DamageSectionComponent:MulticastNotifySetLife",
+            ExportCategory.Gunplay);
+    }
+}
+
+internal sealed class ArmorDamageSectionClassNetCacheDescriptor
+    : ClassNetCacheDescriptor<ArmorDamageSectionClassNetCacheDescriptor>
+{
+    public override string Path =>
+        "/Game/Gear/BasicArmorAttachedDamageSection.BasicArmorAttachedDamageSection_C_ClassNetCache";
+
+    protected override void Configure()
+    {
+        AddFunction<MulticastNotifySetLifeParameters>(
+            "MulticastNotifySetLife",
+            "/Script/ShooterGame.DamageSectionComponent:MulticastNotifySetLife",
+            ExportCategory.Gunplay);
+    }
+}
+
+internal sealed class DamageableComponentClassNetCacheDescriptor
+    : ClassNetCacheDescriptor<DamageableComponentClassNetCacheDescriptor>
+{
+    public override string Path => "/Script/ShooterGame.DamageableComponent_ClassNetCache";
+
+    protected override void Configure()
+    {
+        AddFunction<MulticastNotifyDamageBaseParameters>(
+            "MulticastNotifyDamage_Base",
+            "/Script/ShooterGame.DamageableComponent:MulticastNotifyDamage_Base",
+            ExportCategory.Gunplay);
+        AddFunction<MulticastNotifyDamagePointParameters>(
+            "MulticastNotifyDamage_Point",
+            "/Script/ShooterGame.DamageableComponent:MulticastNotifyDamage_Point",
+            ExportCategory.Gunplay);
+    }
+}
+
+internal sealed class MulticastNotifySetLifeParameters
+    : ExportGroupDescriptor<MulticastNotifySetLifeParameters>
+{
+    public override string Path =>
+        "/Script/ShooterGame.DamageSectionComponent:MulticastNotifySetLife";
+    public override ExportCategory Categories => ExportCategory.Gunplay;
+    public override ExportGroupKind Kind => ExportGroupKind.ClassNetCache;
+    public override FieldStreamGrammar Grammar => FieldStreamGrammar.FunctionParameters;
+
+    public float NewLife { get; set; }
+    public bool NewAlive { get; set; }
+
+    protected override void Configure()
+    {
+        AddProperty(x => x.NewLife).FloatOrRaw();
+        AddProperty("bNewAlive", x => x.NewAlive).BoolOrRaw();
+    }
+}
+
+internal abstract class DamageNotificationParameters<TDescriptor>
+    : ExportGroupDescriptor<TDescriptor>
+    where TDescriptor : DamageNotificationParameters<TDescriptor>
+{
+    public override ExportCategory Categories => ExportCategory.Gunplay;
+    public override ExportGroupKind Kind => ExportGroupKind.ClassNetCache;
+    public override FieldStreamGrammar Grammar => FieldStreamGrammar.FunctionParameters;
+
+    public float DamageTaken { get; set; }
+    public float DamageDealt { get; set; }
+    public bool DamageKilledTarget { get; set; }
+    public bool AliveAfterDamage { get; set; }
+    public uint EventInstigator { get; set; }
+    public uint DamageCauser { get; set; }
+    public object? DamageOrigin { get; set; }
+    public uint EquippableUsed { get; set; }
+    public uint DamageType { get; set; }
+    public object? LifeChangeEvents { get; set; }
+    public uint ChangedComponent { get; set; }
+    public float LifeResult { get; set; }
+    public float DeltaLife { get; set; }
+    public bool AliveAfterChange { get; set; }
+    public uint EventInstigatorPawn { get; set; }
+    public uint DamagerPlayerState { get; set; }
+    public uint KillCreditPlayerState { get; set; }
+    public byte RegionalDamage { get; set; }
+    public uint Character { get; set; }
+    public float NetTimestamp { get; set; }
+    public int RespawnNumber { get; set; }
+    public int VictimRespawnNumber { get; set; }
+
+    protected override void Configure()
+    {
+        AddProperty(x => x.DamageTaken).FloatOrRaw();
+        AddProperty(x => x.DamageDealt).FloatOrRaw();
+        AddProperty("bDamageKilledTarget", x => x.DamageKilledTarget).BoolOrRaw();
+        AddProperty("bAliveAfterDamage", x => x.AliveAfterDamage).BoolOrRaw();
+        AddProperty(x => x.EventInstigator).ObjectNetGuidOrRaw();
+        AddProperty(x => x.DamageCauser).ObjectNetGuidOrRaw();
+        AddProperty(x => x.DamageOrigin)
+            .Decode(ValorantPayloadDecoders.RawPayload("FVector"));
+        AddProperty(x => x.EquippableUsed).ObjectNetGuidOrRaw();
+        AddProperty(x => x.DamageType).ObjectNetGuidOrRaw();
+        AddProperty(x => x.LifeChangeEvents)
+            .Decode(ValorantPayloadDecoders.RawPayload("TArray<FLifeChangeEvent>"));
+        AddProperty(x => x.ChangedComponent).ObjectNetGuidOrRaw();
+        AddProperty(x => x.LifeResult).FloatOrRaw();
+        AddProperty(x => x.DeltaLife).FloatOrRaw();
+        AddProperty("bAliveAfterChange", x => x.AliveAfterChange).BoolOrRaw();
+        AddProperty(x => x.EventInstigatorPawn).ObjectNetGuidOrRaw();
+        AddProperty(x => x.DamagerPlayerState).ObjectNetGuidOrRaw();
+        AddProperty(x => x.KillCreditPlayerState).ObjectNetGuidOrRaw();
+        AddProperty(x => x.RegionalDamage).EnumByteOrRaw();
+        AddProperty(x => x.Character).ObjectNetGuidOrRaw();
+        AddProperty(x => x.NetTimestamp).FloatOrRaw();
+        AddProperty(x => x.RespawnNumber).Int32OrRaw();
+        AddProperty(x => x.VictimRespawnNumber).Int32OrRaw();
+    }
+}
+
+internal sealed class MulticastNotifyDamageBaseParameters
+    : DamageNotificationParameters<MulticastNotifyDamageBaseParameters>
+{
+    public override string Path =>
+        "/Script/ShooterGame.DamageableComponent:MulticastNotifyDamage_Base";
+}
+
+internal sealed class MulticastNotifyDamagePointParameters
+    : DamageNotificationParameters<MulticastNotifyDamagePointParameters>
+{
+    public override string Path =>
+        "/Script/ShooterGame.DamageableComponent:MulticastNotifyDamage_Point";
+}

--- a/tests/Replay.Encoding.Tests/PayloadEncryption/ValorantSeededTransformTests.cs
+++ b/tests/Replay.Encoding.Tests/PayloadEncryption/ValorantSeededTransformTests.cs
@@ -45,6 +45,17 @@ public class ValorantSeededTransformTests
         new("++Ares-Core+release-13.00", 65, "C8336218A9D2979001"),
         new("++Ares-Core+release-13.00", 287, "4FE8F025C0F05BA5DBDD798E8A23E32372F1B49C61C270104E7BD61458C2A433218A1A77"),
         new("++Ares-Core+release-13.00", 288, "8772F8F262B8A7D2A6703E5E961BA7D703AC43D56EE0CC82F4BE1987FC7847365E6B7C32"),
+        new("++Ares-Core+release-13.01", 0, ""),
+        new("++Ares-Core+release-13.01", 1, "00"),
+        new("++Ares-Core+release-13.01", 7, "66"),
+        new("++Ares-Core+release-13.01", 8, "33"),
+        new("++Ares-Core+release-13.01", 31, "C2B2EA65"),
+        new("++Ares-Core+release-13.01", 32, "ABDBCFFA"),
+        new("++Ares-Core+release-13.01", 63, "196EDFE8D117154D"),
+        new("++Ares-Core+release-13.01", 64, "96407A158400136C"),
+        new("++Ares-Core+release-13.01", 65, "9B158480536C754001"),
+        new("++Ares-Core+release-13.01", 287, "03417AC58400D36B853918CF2FD40E14D17390D76FBE6E2343D7236F626CA9FF9163B932"),
+        new("++Ares-Core+release-13.01", 288, "7A3611024CB0D5010F95CEE80D1454FC9BFA0206B31864A0621CF3DAE6B7524FDEFA05A3"),
     ];
 
     [TestCaseSource(nameof(KnownTransformVectors))]
@@ -63,6 +74,7 @@ public class ValorantSeededTransformTests
     [TestCase("++Ares-Core+release-12.10", 31)]
     [TestCase("++Ares-Core+release-12.11", 64)]
     [TestCase("++Ares-Core+release-13.00", 65)]
+    [TestCase("++Ares-Core+release-13.01", 65)]
     public void Apply_WithExplicitBitCount_ConsumesOnlyRequestedPayloadBits(string replayVersion, int bitCount)
     {
         var bytes = Convert.FromHexString(PayloadHex);
@@ -126,6 +138,7 @@ public class ValorantSeededTransformTests
         Assert.That(registry.GetRequired("++Ares-Core+release-12.10"), Is.Not.Null);
         Assert.That(registry.GetRequired("++Ares-Core+release-12.11"), Is.Not.Null);
         Assert.That(registry.GetRequired("++Ares-Core+release-13.00"), Is.Not.Null);
+        Assert.That(registry.GetRequired("++Ares-Core+release-13.01"), Is.Not.Null);
     }
 
     [Test]

--- a/tests/Replay.Unreal.Tests/Parsing/ExportBindingRegistryTests.cs
+++ b/tests/Replay.Unreal.Tests/Parsing/ExportBindingRegistryTests.cs
@@ -25,6 +25,21 @@ public class ExportBindingRegistryTests
     }
 
     [Test]
+    public void OnExportGroupAdded_BindsDefaultObjectToShortClassPath()
+    {
+        var registry = CreateRegistry(catalog => catalog.Add(new TestDescriptor()));
+        registry.OnExportGroupAdded(CreateReplayGroup("Default__Test_C", exports:
+        [
+            (0u, "FieldA"),
+        ]));
+
+        var bound = registry.GetBoundGroup("Test_C");
+
+        Assert.That(bound, Is.Not.Null);
+        Assert.That(bound!.FieldsByHandle[0].Enabled, Is.True);
+    }
+
+    [Test]
     public void GetExportGroupKind_UsesDescriptorBeforeReplayGroupIsBound()
     {
         var registry = CreateRegistry(catalog => catalog.Add(new TestDescriptor()));

--- a/tests/Replay.Valorant.Tests/Descriptors/ValorantDescriptorsTests.cs
+++ b/tests/Replay.Valorant.Tests/Descriptors/ValorantDescriptorsTests.cs
@@ -64,10 +64,20 @@ public class ValorantDescriptorsTests
             "/Script/ShooterGame.EquippableStateMachineComponent",
             "/Script/ShooterGame.AmmoComponent",
             "/Script/ShooterGame.AresAttributeSet",
+            "/Script/ShooterGame.AbilityRechargeComponent",
+            "/Script/ShooterGame.AbilityRechargeCooldownComponent",
+            "/Script/ShooterGame.ResourceComponent",
+            "/Script/ShooterGame.AbilityResourceComponent",
+            "/Script/ShooterGame.EquipmentChargeComponent",
+            "/Script/ShooterGame.SignatureAbilityResourceComponent",
+            "/Game/Characters/Components/Comp_Ability_CooldownComponent.Comp_Ability_CooldownComponent_C",
             "/Script/ShooterGame.ChildDamageSectionComponent",
             "/Script/ShooterGame.ChildRegionDamageSectionComponent",
             "/Script/ShooterGame.AttachedDamageSectionComponent",
             "/Script/ShooterGame.FiringStateComponent",
+            "/Game/Gear/LightArmorItem.LightArmorItem_C",
+            "/Game/Gear/HeavyArmorItem.HeavyArmorItem_C",
+            "/Game/Gear/PlasmaArmor/PlasmaArmorItem.PlasmaArmorItem_C",
             "/Game/Characters/Phoenix/S0/Ability_Q/Production/Projectile_Phoenix_Q_FlameWall_ThroughWall.Projectile_Phoenix_Q_FlameWall_ThroughWall_C",
         ];
 
@@ -117,6 +127,20 @@ public class ValorantDescriptorsTests
                 "MulticastReceivePlayerTemporaryDeathEvent_Point",
                 "MulticastSetPhase",
                 "MulticastResetForRespawn");
+            AssertFunctions(
+                cacheDescriptors["/Script/ShooterGame.ChildDamageSectionComponent_ClassNetCache"],
+                "MulticastNotifySetLife");
+            AssertFunctions(
+                cacheDescriptors["/Script/ShooterGame.AttachedDamageSectionComponent_ClassNetCache"],
+                "MulticastNotifySetLife");
+            AssertFunctions(
+                cacheDescriptors[
+                    "/Game/Gear/BasicArmorAttachedDamageSection.BasicArmorAttachedDamageSection_C_ClassNetCache"],
+                "MulticastNotifySetLife");
+            AssertFunctions(
+                cacheDescriptors["/Script/ShooterGame.DamageableComponent_ClassNetCache"],
+                "MulticastNotifyDamage_Base",
+                "MulticastNotifyDamage_Point");
         });
     }
 

--- a/tests/Replay.Valorant.Tests/Export/ReplayExportTests.cs
+++ b/tests/Replay.Valorant.Tests/Export/ReplayExportTests.cs
@@ -7,6 +7,7 @@ using Replay.Models.Net;
 using Replay.Models.Replay;
 using Replay.Models.Unreal;
 using Replay.Unreal.Readers;
+using Replay.Valorant.GameState;
 using Replay.Valorant.Movement;
 
 namespace Replay.Valorant.Tests.Export;
@@ -50,6 +51,9 @@ public class ReplayExportTests
             {
                 Assert.That(sink.EventCount, Is.EqualTo(4));
                 Assert.That(sink.FilteredExportGroupCount, Is.EqualTo(2));
+                Assert.That(sink.UndecodedExportGroupCount, Is.EqualTo(1));
+                Assert.That(sink.EmptyDecodedExportGroupCount, Is.EqualTo(1));
+                Assert.That(sink.FilteredExportGroups.Count, Is.EqualTo(2));
             });
         }
 
@@ -79,6 +83,30 @@ public class ReplayExportTests
         });
 
         Dispose(documents);
+    }
+
+    [Test]
+    public void EventSink_WritesStructuredRoundResultPayload()
+    {
+        using var events = new MemoryStream();
+        using var movement = new MemoryStream();
+        using (var sink = CreateSink(events, movement))
+        {
+            sink.Emit(Export(wasDecoded: true, payload: new RoundResultPayload()));
+        }
+
+        using var document = ParseLines(events).Single();
+        var result = document.RootElement
+            .GetProperty("payload")
+            .GetProperty("RoundResults")[0];
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.GetProperty("RoundNumber").GetInt32(), Is.Zero);
+            Assert.That(result.GetProperty("WinningTeam").GetString(), Is.EqualTo("Blue"));
+            Assert.That(result.GetProperty("WinningTeamRole").GetString(), Is.EqualTo("defender"));
+            Assert.That(result.GetProperty("RoundResult").GetString(), Is.EqualTo("defuse"));
+        });
     }
 
     [Test]
@@ -137,6 +165,7 @@ public class ReplayExportTests
             using var movement = new MemoryStream();
             using var sink = CreateSink(events, movement);
             sink.Emit(Spawned());
+            sink.Emit(Export(wasDecoded: false, payload: null));
 
             new ReplayExportManifestWriter().Write(
                 directory,
@@ -151,13 +180,25 @@ public class ReplayExportTests
             var manifest = document.RootElement;
             Assert.Multiple(() =>
             {
-                Assert.That(manifest.GetProperty("schema_version").GetInt32(), Is.EqualTo(1));
+                Assert.That(manifest.GetProperty("schema_version").GetInt32(), Is.EqualTo(3));
                 Assert.That(manifest.GetProperty("source_sha256").GetString(), Has.Length.EqualTo(64));
                 Assert.That(manifest.GetProperty("replay_build").GetString(), Does.EndWith("release-13.01"));
                 Assert.That(manifest.GetProperty("duration_ms").GetInt32(), Is.EqualTo(60000));
                 Assert.That(manifest.GetProperty("parse_profile").GetString(), Is.EqualTo("viewer"));
                 Assert.That(manifest.GetProperty("parser_version").GetString(), Is.Not.Empty);
                 Assert.That(manifest.GetProperty("counts").GetProperty("actor_spawned").GetInt32(), Is.EqualTo(1));
+                Assert.That(manifest.GetProperty("net_field_export_groups").GetArrayLength(), Is.Zero);
+                Assert.That(
+                    manifest.GetProperty("counts").GetProperty("undecoded_export_groups").GetInt32(),
+                    Is.EqualTo(1));
+                Assert.That(
+                    manifest.GetProperty("filtered_export_group_summary")[0]
+                        .GetProperty("path").GetString(),
+                    Is.EqualTo("/Game/Export"));
+                Assert.That(
+                    manifest.GetProperty("filtered_export_group_summary")[0]
+                        .GetProperty("sample_class_path").GetString(),
+                    Is.EqualTo("/Game/Class"));
                 Assert.That(manifest.GetProperty("limitations").GetArrayLength(), Is.GreaterThan(0));
             });
         }
@@ -286,5 +327,13 @@ public class ReplayExportTests
         public string Ignored { get; } = "not decoded";
 
         public bool HasDecoded(string propertyName) => DecodedProperties.Contains(propertyName);
+    }
+
+    private sealed class RoundResultPayload
+    {
+        public AresRoundResult[] RoundResults { get; } =
+        [
+            new(0, "Blue", AresTeamRole.Defender, AresRoundOutcome.Defuse),
+        ];
     }
 }

--- a/tests/Replay.Valorant.Tests/Export/ReplayExportTests.cs
+++ b/tests/Replay.Valorant.Tests/Export/ReplayExportTests.cs
@@ -1,0 +1,290 @@
+using System.Text.Json;
+using CliReader;
+using Replay.Encoding.Archives;
+using Replay.Models.Descriptors;
+using Replay.Models.Events;
+using Replay.Models.Net;
+using Replay.Models.Replay;
+using Replay.Models.Unreal;
+using Replay.Unreal.Readers;
+using Replay.Valorant.Movement;
+
+namespace Replay.Valorant.Tests.Export;
+
+public class ReplayExportTests
+{
+    [Test]
+    public void ExportOptions_ParsesViewerProfile()
+    {
+        var parsed = ExportOptions.TryParse(
+            ["export", "match.replay", "--output", "bundle", "--profile", "viewer"],
+            out var options,
+            out var error);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(parsed, Is.True);
+            Assert.That(error, Is.Null);
+            Assert.That(options!.ReplayPath, Is.EqualTo("match.replay"));
+            Assert.That(options.OutputDirectory, Is.EqualTo("bundle"));
+            Assert.That(options.ProfileName, Is.EqualTo("viewer"));
+            Assert.That(options.ParseProfile.CaptureDiagnosticFields, Is.True);
+        });
+    }
+
+    [Test]
+    public void EventSink_WritesSupportedEventsAndFiltersExportShells()
+    {
+        using var events = new MemoryStream();
+        using var movement = new MemoryStream();
+        using (var sink = CreateSink(events, movement))
+        {
+            sink.Emit(Spawned());
+            sink.Emit(new ActorClosed(2, 12, 100, 7, ChannelCloseReason.Destroyed));
+            sink.Emit(Export(wasDecoded: false, payload: new TestPayload()));
+            sink.Emit(Export(wasDecoded: true, payload: null));
+            sink.Emit(Export(wasDecoded: true, payload: new TestPayload()));
+            sink.Emit(Rpc());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(sink.EventCount, Is.EqualTo(4));
+                Assert.That(sink.FilteredExportGroupCount, Is.EqualTo(2));
+            });
+        }
+
+        var documents = ParseLines(events);
+        Assert.That(
+            documents.Select(document => document.RootElement.GetProperty("type").GetString()),
+            Is.EqualTo(new[]
+            {
+                "actor_spawned",
+                "actor_closed",
+                "export_group_received",
+                "rpc_received",
+            }));
+
+        var exported = documents[2].RootElement;
+        Assert.Multiple(() =>
+        {
+            Assert.That(exported.GetProperty("time_ms").GetInt64(), Is.EqualTo(2500));
+            Assert.That(exported.GetProperty("actor_net_guid").GetUInt32(), Is.EqualTo(100));
+            Assert.That(exported.GetProperty("object_net_guid").GetUInt32(), Is.EqualTo(101));
+            Assert.That(exported.GetProperty("channel").GetUInt32(), Is.EqualTo(7));
+            Assert.That(exported.GetProperty("was_decoded").GetBoolean(), Is.True);
+            Assert.That(exported.GetProperty("categories")[0].GetString(), Is.EqualTo("movement"));
+            Assert.That(exported.GetProperty("payload").GetProperty("Health").GetInt32(), Is.EqualTo(87));
+            Assert.That(exported.GetProperty("payload").TryGetProperty("Ignored", out _), Is.False);
+            Assert.That(documents[3].RootElement.GetProperty("was_decoded").GetBoolean(), Is.False);
+        });
+
+        Dispose(documents);
+    }
+
+    [Test]
+    public void MovementSink_WritesMachineReadableMovementShape()
+    {
+        using var events = new MemoryStream();
+        using var movement = new MemoryStream();
+        using (var sink = CreateSink(events, movement))
+        {
+            var move = Movement();
+            sink.EmitRemoteCharacterMovement(1.25f, 99, 100, 101, 7, 3, 1234, 4, in move);
+        }
+
+        var documents = ParseLines(movement);
+        var exported = documents.Single().RootElement;
+        Assert.Multiple(() =>
+        {
+            Assert.That(exported.GetProperty("type").GetString(), Is.EqualTo("remote_character_movement"));
+            Assert.That(exported.GetProperty("time_ms").GetInt64(), Is.EqualTo(1250));
+            Assert.That(exported.GetProperty("packet_id").GetInt32(), Is.EqualTo(99));
+            Assert.That(exported.GetProperty("shooter_character_net_guid").GetUInt32(), Is.EqualTo(1234));
+            Assert.That(exported.GetProperty("update_index").GetInt32(), Is.EqualTo(3));
+            Assert.That(exported.GetProperty("move_index").GetInt32(), Is.EqualTo(4));
+            Assert.That(exported.GetProperty("position").GetProperty("x").GetDouble(), Is.EqualTo(1.5));
+            Assert.That(exported.GetProperty("velocity").GetProperty("z").GetDouble(), Is.EqualTo(6));
+            Assert.That(exported.GetProperty("yaw").GetDouble(), Is.EqualTo(90));
+            Assert.That(exported.GetProperty("pitch").GetDouble(), Is.EqualTo(45));
+            Assert.That(exported.GetProperty("timestamp").GetUInt32(), Is.EqualTo(42));
+            Assert.That(exported.GetProperty("movement_state").GetByte(), Is.EqualTo(3));
+        });
+
+        Dispose(documents);
+    }
+
+    [Test]
+    public void ManifestWriter_WritesSchemaIdentityAndCounts()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"valorant-export-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            using var archive = new FBinaryArchive(ReadOnlyMemory<byte>.Empty);
+            var context = new ReplayReaderContext(archive)
+            {
+                ReplayInfo = new ReplayInfo { LengthInMs = 60000 },
+                ReplayVersion = new ReplayVersion
+                {
+                    Major = 13,
+                    Minor = 1,
+                    Patch = 0,
+                    Changelist = 123,
+                    Branch = "++Ares-Core+release-13.01",
+                },
+            };
+            using var events = new MemoryStream();
+            using var movement = new MemoryStream();
+            using var sink = CreateSink(events, movement);
+            sink.Emit(Spawned());
+
+            new ReplayExportManifestWriter().Write(
+                directory,
+                "match.replay",
+                new string('a', 64),
+                42,
+                "viewer",
+                context,
+                sink);
+
+            using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(directory, "manifest.json")));
+            var manifest = document.RootElement;
+            Assert.Multiple(() =>
+            {
+                Assert.That(manifest.GetProperty("schema_version").GetInt32(), Is.EqualTo(1));
+                Assert.That(manifest.GetProperty("source_sha256").GetString(), Has.Length.EqualTo(64));
+                Assert.That(manifest.GetProperty("replay_build").GetString(), Does.EndWith("release-13.01"));
+                Assert.That(manifest.GetProperty("duration_ms").GetInt32(), Is.EqualTo(60000));
+                Assert.That(manifest.GetProperty("parse_profile").GetString(), Is.EqualTo("viewer"));
+                Assert.That(manifest.GetProperty("parser_version").GetString(), Is.Not.Empty);
+                Assert.That(manifest.GetProperty("counts").GetProperty("actor_spawned").GetInt32(), Is.EqualTo(1));
+                Assert.That(manifest.GetProperty("limitations").GetArrayLength(), Is.GreaterThan(0));
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static ReplayExportSink CreateSink(Stream events, Stream movement) =>
+        new(
+            new NdjsonWriter(events),
+            new NdjsonWriter(movement),
+            new ReplayJsonNormalizer());
+
+    private static ActorSpawned Spawned() =>
+        new(
+            1,
+            10,
+            100,
+            7,
+            true,
+            "/Game/Actor",
+            200,
+            "/Game/Archetype",
+            "/Game/Class",
+            300,
+            new FVector(1, 2, 3),
+            new FRotator(4, 5, 6),
+            new FVector(1, 1, 1),
+            new FVector(7, 8, 9));
+
+    private static ExportGroupReceived Export(bool wasDecoded, object? payload) =>
+        new(
+            2.5f,
+            20,
+            100,
+            101,
+            7,
+            false,
+            false,
+            0,
+            "/Game/Export",
+            ExportGroupKind.Component,
+            ExportCategory.Movement | ExportCategory.Agent,
+            200,
+            100,
+            "/Game/Object",
+            "/Game/Class",
+            "/Game/Outer",
+            64,
+            64,
+            wasDecoded,
+            payload,
+            wasDecoded ? 1 : 0,
+            []);
+
+    private static RpcReceived Rpc() =>
+        new(
+            3,
+            30,
+            100,
+            101,
+            7,
+            "/Game/Class",
+            "DoThing",
+            "/Game/Class.DoThing",
+            9,
+            ExportCategory.Ability,
+            8,
+            0,
+            false,
+            null,
+            0,
+            []);
+
+    private static MovementMove Movement() =>
+        new(
+            Marker: 1,
+            MoveType: 1,
+            Position: new FVector(1.5, 2.5, 3.5),
+            Velocity: new FVector(4, 5, 6),
+            RotationInput: new FVector(0.1, 0.2, 0.3),
+            Variant1Vector: new FVector(4, 5, 6),
+            Timestamp: 42,
+            ModeFlags: 3,
+            MovementState: 3,
+            RotationYawMultiplier: 2,
+            UnusedByte: 0,
+            HasOptionalMovementValue: true,
+            OptionalMovementRawByte: 8,
+            OptionalMovementValue: 8,
+            Flag48: false,
+            PackedAngles: 12,
+            RawYaw: 100,
+            RawPitch: 200,
+            Yaw: 90,
+            Pitch: 45,
+            Variant0HasExternalCharacterRef: null,
+            Variant0PackedAngles: null,
+            Variant1Flag: true,
+            ErrorSentinel: false);
+
+    private static List<JsonDocument> ParseLines(MemoryStream stream) =>
+        System.Text.Encoding.UTF8.GetString(stream.ToArray())
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => JsonDocument.Parse(line))
+            .ToList();
+
+    private static void Dispose(IEnumerable<JsonDocument> documents)
+    {
+        foreach (var document in documents)
+        {
+            document.Dispose();
+        }
+    }
+
+    private sealed class TestPayload : IDecodedPayload
+    {
+        public IReadOnlySet<string> DecodedProperties { get; } = new HashSet<string>
+        {
+            nameof(Health),
+        };
+
+        public int Health { get; } = 87;
+        public string Ignored { get; } = "not decoded";
+
+        public bool HasDecoded(string propertyName) => DecodedProperties.Contains(propertyName);
+    }
+}

--- a/tests/Replay.Valorant.Tests/GameState/AresRoundResultsDecoderTests.cs
+++ b/tests/Replay.Valorant.Tests/GameState/AresRoundResultsDecoderTests.cs
@@ -1,0 +1,210 @@
+using Replay.Encoding.Archives;
+using Replay.Models.Descriptors;
+using Replay.Unreal.Parsing;
+using Replay.Valorant.Descriptors;
+using Replay.Valorant.GameState;
+
+namespace Replay.Valorant.Tests.GameState;
+
+public class AresRoundResultsDecoderTests
+{
+    [Test]
+    public void Decode_EmitsRoundIndexAndWinnerFields()
+    {
+        var archive = CreateArchive(writer =>
+        {
+            writer.WriteIntPacked(3);
+            writer.WriteIntPacked(3);
+            WriteField(writer, 93, payload => payload.WriteFName("Blue"));
+            WriteField(writer, 94, payload => payload.WriteBits((byte)AresTeamRole.Defender, 3));
+            WriteField(writer, 95, payload => payload.WriteBits((byte)AresRoundOutcome.Defuse, 4));
+            writer.WriteIntPacked(0);
+            writer.WriteIntPacked(0);
+        });
+        var context = new FieldDecodeContext();
+
+        var value = Decoder().Decode(ref context, archive);
+        var results = (AresRoundResult[])value.ObjectValue!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(results, Has.Length.EqualTo(1));
+            Assert.That(results[0].RoundNumber, Is.EqualTo(2));
+            Assert.That(results[0].WinningTeam, Is.EqualTo("Blue"));
+            Assert.That(results[0].WinningTeamRole, Is.EqualTo(AresTeamRole.Defender));
+            Assert.That(results[0].RoundResult, Is.EqualTo(AresRoundOutcome.Defuse));
+            Assert.That(archive.AtEnd, Is.True);
+        });
+    }
+
+    [TestCase(
+        "0202BCD20A00000084D8EACA00000000007C0D048C00C2800202C420D90400000000",
+        272,
+        0,
+        "Blue",
+        AresTeamRole.Defender,
+        AresRoundOutcome.Elimination)]
+    [TestCase(
+        "0606BCC208000000A4CAC800000000007C0D028C200000",
+        184,
+        2,
+        "Red",
+        AresTeamRole.Attacker,
+        AresRoundOutcome.Detonate)]
+    public void Decode_DecodesRelease1301ReplayPayload(
+        string hex,
+        int bitCount,
+        int roundNumber,
+        string winningTeam,
+        AresTeamRole winningTeamRole,
+        AresRoundOutcome roundResult)
+    {
+        var archive = new BitArchiveReader(Convert.FromHexString(hex), bitCount);
+        var context = new FieldDecodeContext();
+
+        var value = Decoder().Decode(ref context, archive);
+        var result = ((AresRoundResult[])value.ObjectValue!).Single();
+
+        Assert.That(
+            result,
+            Is.EqualTo(new AresRoundResult(roundNumber, winningTeam, winningTeamRole, roundResult)));
+        Assert.That(archive.AtEnd, Is.True);
+    }
+
+    [Test]
+    public void Decode_RejectsRoundCountAboveBound()
+    {
+        var archive = CreateArchive(writer => writer.WriteIntPacked(129));
+        var context = new FieldDecodeContext();
+
+        var exception = Assert.Throws<ArchiveReadException>(() => Decoder().Decode(ref context, archive));
+
+        Assert.That(exception!.ErrorCode, Is.EqualTo(ArchiveErrorCode.InvalidCount));
+    }
+
+    [Test]
+    public void Decode_RejectsTrailingBitsInsideKnownField()
+    {
+        var archive = CreateArchive(writer =>
+        {
+            writer.WriteIntPacked(1);
+            writer.WriteIntPacked(1);
+            WriteField(writer, 93, payload =>
+            {
+                payload.WriteFName("Red");
+                payload.WriteBit(true);
+            });
+            writer.WriteIntPacked(0);
+            writer.WriteIntPacked(0);
+        });
+        var context = new FieldDecodeContext();
+
+        var exception = Assert.Throws<ArchiveReadException>(() => Decoder().Decode(ref context, archive));
+
+        Assert.That(exception!.ErrorCode, Is.EqualTo(ArchiveErrorCode.UnexpectedTrailingData));
+    }
+
+    [Test]
+    public void Decode_PreservesRawPayloadForOlderHandleLayout()
+    {
+        var archive = CreateArchive(writer =>
+        {
+            writer.WriteIntPacked(1);
+            writer.WriteIntPacked(1);
+            WriteField(writer, 0, payload => payload.WriteBit(true));
+            writer.WriteIntPacked(0);
+            writer.WriteIntPacked(0);
+        });
+        var bitCount = archive.BitLength;
+        var context = new FieldDecodeContext();
+
+        var value = Decoder().Decode(ref context, archive);
+        var raw = (ValorantRawPayload)value.ObjectValue!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(raw.TypeName, Is.EqualTo("TArray<FAresRoundResult>"));
+            Assert.That(raw.BitCount, Is.EqualTo(bitCount));
+            Assert.That(archive.AtEnd, Is.True);
+        });
+    }
+
+    private static IFieldDecoder Decoder() =>
+        (IFieldDecoder)ValorantDescriptors.CreateCatalog()
+            .ExportGroupDescriptors
+            .Single(descriptor => descriptor.Path == "/Game/GameModes/Bomb/BombGameState.BombGameState_C")
+            .Fields
+            .Single(field => field.ExportName == "RoundResults")
+            .Decoder!;
+
+    private static BitArchiveReader CreateArchive(Action<BitWriter> write)
+    {
+        var writer = new BitWriter();
+        write(writer);
+        return new BitArchiveReader(writer.ToArray(), writer.BitCount);
+    }
+
+    private static void WriteField(BitWriter writer, uint handle, Action<BitWriter> writePayload)
+    {
+        var payload = new BitWriter();
+        writePayload(payload);
+        writer.WriteIntPacked(handle + 1);
+        writer.WriteIntPacked((uint)payload.BitCount);
+        writer.WriteBits(payload.ToArray(), payload.BitCount);
+    }
+
+    private sealed class BitWriter
+    {
+        private readonly List<bool> _bits = [];
+
+        public int BitCount => _bits.Count;
+
+        public void WriteBit(bool value) => _bits.Add(value);
+
+        public void WriteBits(byte value, int bitCount)
+        {
+            for (var i = 0; i < bitCount; i++) WriteBit((value & (1 << i)) != 0);
+        }
+
+        public void WriteBits(byte[] bytes, int bitCount)
+        {
+            for (var i = 0; i < bitCount; i++) WriteBit((bytes[i >> 3] & (1 << (i & 7))) != 0);
+        }
+
+        public void WriteFName(string value)
+        {
+            WriteBit(false);
+            var bytes = System.Text.Encoding.UTF8.GetBytes(value + '\0');
+            WriteInt32(bytes.Length);
+            WriteBits(bytes, bytes.Length * 8);
+            WriteInt32(0);
+        }
+
+        public void WriteInt32(int value)
+        {
+            foreach (var item in BitConverter.GetBytes(value)) WriteBits(item, 8);
+        }
+
+        public void WriteIntPacked(uint value)
+        {
+            do
+            {
+                var next = (byte)((value & 0x7F) << 1);
+                value >>= 7;
+                if (value != 0) next |= 1;
+                WriteBits(next, 8);
+            } while (value != 0);
+        }
+
+        public byte[] ToArray()
+        {
+            var bytes = new byte[(_bits.Count + 7) / 8];
+            for (var i = 0; i < _bits.Count; i++)
+            {
+                if (_bits[i]) bytes[i >> 3] |= (byte)(1 << (i & 7));
+            }
+
+            return bytes;
+        }
+    }
+}

--- a/tests/Replay.Valorant.Tests/GameState/CombatRoundReportsDecoderTests.cs
+++ b/tests/Replay.Valorant.Tests/GameState/CombatRoundReportsDecoderTests.cs
@@ -1,0 +1,52 @@
+using Replay.Encoding.Archives;
+using Replay.Models.Descriptors;
+using Replay.Unreal.Parsing;
+using Replay.Valorant.Descriptors;
+using Replay.Valorant.GameState;
+
+namespace Replay.Valorant.Tests.GameState;
+
+public class CombatRoundReportsDecoderTests
+{
+    [Test]
+    public void Decode_DecodesRelease1301RoundAndCharacterEnvelope()
+    {
+        const string payload =
+            "AgIIQAAAAAAKMwwCAgxAAAAAAA4gNyIQQAAAgL8SQAAAgL8UEP7GEADIID8cykAE8O9BzEAAAAAAzhAC0AKkAwUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACoQW5ErIEAAAB/sYEAAAB/tSH8AQAAAAA=";
+        var archive = new BitArchiveReader(Convert.FromBase64String(payload), 897);
+        var context = new FieldDecodeContext();
+
+        var value = Decoder().Decode(ref context, archive);
+        var rounds = (CombatRoundReportUpdate[])value.ObjectValue!;
+        var report = rounds.Single().Reports.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(rounds.Single().RoundNumber, Is.Zero);
+            Assert.That(report.RoundNumber, Is.Zero);
+            Assert.That(report.Died, Is.False);
+            Assert.That(archive.AtEnd, Is.True);
+        });
+    }
+
+    [Test]
+    public void Decode_DecodesParticipantDamageUpdates()
+    {
+        const string payload =
+            "AgIKVRwCAg4gcy4QQG6awUISQAAAQEIUEAQWtRgCAhiRBCUAAAA3YmVhMzNjMC02N2JhLTViODgtYjY1NS01ODI2ZTcwODkzZDMAGsIIAAAApMrIAAAAAAA4QJZgPEDmXECA3DSDhUSAAACAhEggCEyAADggglCAAgAAAFSAAAAAAFiAAAAAAFwEwCgAGQgAGgE2tQgCAjggcy46QG6awUI8QAAAQEI+EARAIHMuQkBumsFCREAAAEBCRhAESCArMFqlAgICXBAAXkABAAAAYEAAHBBBYgLIBJhBAAAAAAAIAwUAAAAAAAAAAAAA";
+        var archive = new BitArchiveReader(Convert.FromBase64String(payload), 1890);
+        var context = new FieldDecodeContext();
+
+        var value = Decoder().Decode(ref context, archive);
+        var participants = ((CombatRoundReportUpdate[])value.ObjectValue!)
+            .SelectMany(round => round.Reports)
+            .SelectMany(report => report.Interactions)
+            .ToArray();
+
+        Assert.That(participants, Is.Not.Empty);
+        Assert.That(participants.Any(item => item.Subject is not null), Is.True);
+        Assert.That(archive.AtEnd, Is.True);
+    }
+
+    private static IFieldDecoder Decoder() => new CombatRoundReportsDecoder();
+}

--- a/tests/Replay.Valorant.Tests/Replay.Valorant.Tests.csproj
+++ b/tests/Replay.Valorant.Tests/Replay.Valorant.Tests.csproj
@@ -21,6 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\src\CliReader\CliReader.csproj" />
       <ProjectReference Include="..\..\src\Replay.Models\Replay.Models.csproj" />
       <ProjectReference Include="..\..\src\Replay.Valorant\Replay.Valorant.csproj" />
     </ItemGroup>

--- a/tests/Test.Integration/ReplayReaderIntegrationTests.cs
+++ b/tests/Test.Integration/ReplayReaderIntegrationTests.cs
@@ -65,15 +65,15 @@ public class ReplayReaderIntegrationTests
 
     [Test]
     public void ReadRawPackets_12_10_RecordsStats() =>
-        ReadRawPacketsRecordsStats("9f8b32c5-c243-41ec-bbbb-832582edf652.12_10.vrf", expectedPartialErrors: 2, expectedMalformedPayloads: 1);
+        ReadRawPacketsRecordsStats("9f8b32c5-c243-41ec-bbbb-832582edf652.12_10.vrf", expectedPartialErrors: 2, expectedMalformedPayloads: 0);
 
     [Test]
     public void ReadRawPackets_12_11_RecordsStats() =>
-        ReadRawPacketsRecordsStats("5c673443-5bdc-4576-b416-aab3f62471a5.12_11.vrf", expectedPartialErrors: 2, expectedMalformedPayloads: 1);
+        ReadRawPacketsRecordsStats("5c673443-5bdc-4576-b416-aab3f62471a5.12_11.vrf", expectedPartialErrors: 2, expectedMalformedPayloads: 0);
 
     [Test]
     public void ReadRawPackets_13_00_RecordsStats() =>
-        ReadRawPacketsRecordsStats(Replay13_00, expectedPartialErrors: 2, expectedMalformedPayloads: 2);
+        ReadRawPacketsRecordsStats(Replay13_00, expectedPartialErrors: 2, expectedMalformedPayloads: 1);
 
     [Test]
     public void ReadRawPackets_12_11_EmitsTimedParserEvents()


### PR DESCRIPTION
This pull request introduces a new "export" command to the `CliReader` tool, enabling users to export replay data to a specified directory with a manifest describing the export. The implementation includes command-line parsing, manifest generation, error handling, and supporting infrastructure for writing NDJSON files and tracking export statistics.

The most important changes are:

**Export Command Implementation:**

* Added a new `ExportOptions` record in `ExportOptions.cs` to parse and validate export command-line arguments, supporting an optional `--profile viewer` argument and requiring an output directory.
* Updated `Program.cs` to handle the new "export" command, invoking a new export runner and providing user feedback and error handling for file access issues. [[1]](diffhunk://#diff-d1356571fba94ac5e2d9108bf67eb55da6666bf062f7105d9c896cebfd638c23R23-R39) [[2]](diffhunk://#diff-d1356571fba94ac5e2d9108bf67eb55da6666bf062f7105d9c896cebfd638c23R83-R92)

**Export Process and Manifest Generation:**

* Introduced `ReplayExportRunner` to coordinate the export process, including reading the replay file, calculating its SHA256 hash, running the export, and invoking manifest generation.
* Added `ReplayExportManifestWriter` to generate a detailed `manifest.json` file summarizing the export, including schema version, source file details, replay metadata, statistics, and limitations.

**Supporting Infrastructure:**

* Added `NdjsonWriter` for writing newline-delimited JSON output streams, which can be used for exporting replay data in the export process.
* Marked internal types as visible to the test project by adding `InternalsVisibleTo` in `AssemblyInfo.cs` for improved testability.